### PR TITLE
feat(collector): add plugin, hook, and DB table metrics

### DIFF
--- a/includes/class-bigquery-client.php
+++ b/includes/class-bigquery-client.php
@@ -131,10 +131,19 @@ class ProPerf_BigQuery_Client {
 			rewind( $stream );
 			$schema = array(
 				'fields' => array(
-					array( 'name' => 'timestamp_utc', 'type' => 'TIMESTAMP' ),
+					array( 'name' => 'timestamp_utc',           'type' => 'TIMESTAMP' ),
+					array( 'name' => 'site_url',                'type' => 'STRING' ),
+					// Autoload.
 					array( 'name' => 'autoloaded_option_count', 'type' => 'INTEGER' ),
-					array( 'name' => 'autoloaded_option_size', 'type' => 'INTEGER' ),
-					array( 'name' => 'site_url', 'type' => 'STRING' ),
+					array( 'name' => 'autoloaded_option_size',  'type' => 'INTEGER' ),
+					// Plugins.
+					array( 'name' => 'active_plugin_count',     'type' => 'INTEGER' ),
+					array( 'name' => 'inactive_plugin_count',   'type' => 'INTEGER' ),
+					array( 'name' => 'total_plugin_count',      'type' => 'INTEGER' ),
+					// Hooks.
+					array( 'name' => 'hook_count',              'type' => 'INTEGER' ),
+					// Database.
+					array( 'name' => 'db_total_size_bytes',     'type' => 'INTEGER' ),
 				),
 			);
 

--- a/includes/class-bigquery-client.php
+++ b/includes/class-bigquery-client.php
@@ -143,7 +143,12 @@ class ProPerf_BigQuery_Client {
 					// Hooks.
 					array( 'name' => 'hook_count',              'type' => 'INTEGER' ),
 					// Database.
-					array( 'name' => 'db_total_size_bytes',     'type' => 'INTEGER' ),
+					array( 'name' => 'db_total_size_bytes',              'type' => 'INTEGER' ),
+					// WooCommerce orders.
+					array( 'name' => 'woo_order_items_size_bytes',       'type' => 'INTEGER' ),
+					array( 'name' => 'woo_order_itemmeta_size_bytes',    'type' => 'INTEGER' ),
+					array( 'name' => 'woo_oldest_order_age_days',        'type' => 'INTEGER' ),
+					array( 'name' => 'woo_archival_trigger',             'type' => 'INTEGER' ),
 				),
 			);
 

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -24,7 +24,8 @@ class ProPerf_Data_Collector {
 			$this->collect_autoloaded_options(),
 			$this->collect_plugin_metrics(),
 			$this->collect_hook_metrics(),
-			$this->collect_db_table_metrics()
+			$this->collect_db_table_metrics(),
+			$this->collect_woo_order_metrics()
 		);
 	}
 
@@ -158,6 +159,70 @@ class ProPerf_Data_Collector {
 	}
 
 	/**
+	 * Collect WooCommerce order table metrics.
+	 *
+	 * Measures order_items and order_itemmeta table sizes, oldest order age,
+	 * and sets an archival trigger flag when orders older than 365 days exist.
+	 * Returns zeros with woo_active=false when WooCommerce is not installed.
+	 *
+	 * @return array WooCommerce order metrics.
+	 */
+	public function collect_woo_order_metrics() {
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return array(
+				'woo_orders' => array(
+					'woo_active'                  => false,
+					'order_items_size_bytes'       => 0,
+					'order_itemmeta_size_bytes'    => 0,
+					'oldest_order_age_days'        => 0,
+					'archival_trigger'             => false,
+				),
+			);
+		}
+
+		global $wpdb;
+
+		$order_items_table    = $wpdb->prefix . 'woocommerce_order_items';
+		$order_itemmeta_table = $wpdb->prefix . 'woocommerce_order_itemmeta';
+
+		$order_items_size = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT ROUND(data_length + index_length)
+				 FROM information_schema.tables
+				 WHERE table_schema = DATABASE() AND table_name = %s',
+				$order_items_table
+			)
+		);
+
+		$order_itemmeta_size = $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT ROUND(data_length + index_length)
+				 FROM information_schema.tables
+				 WHERE table_schema = DATABASE() AND table_name = %s',
+				$order_itemmeta_table
+			)
+		);
+
+		$oldest_order_age_days = $wpdb->get_var(
+			"SELECT DATEDIFF(NOW(), MIN(post_date))
+			 FROM {$wpdb->posts}
+			 WHERE post_type IN ('shop_order', 'wc_order')
+			 AND post_status != 'trash'"
+		);
+		$oldest_order_age_days = $oldest_order_age_days ? intval( $oldest_order_age_days ) : 0;
+
+		return array(
+			'woo_orders' => array(
+				'woo_active'               => true,
+				'order_items_size_bytes'   => $order_items_size ? intval( $order_items_size ) : 0,
+				'order_itemmeta_size_bytes' => $order_itemmeta_size ? intval( $order_itemmeta_size ) : 0,
+				'oldest_order_age_days'    => $oldest_order_age_days,
+				'archival_trigger'         => $oldest_order_age_days > 365,
+			),
+		);
+	}
+
+	/**
 	 * Format metrics for BigQuery.
 	 *
 	 * @param array $metrics Metrics data.
@@ -180,7 +245,12 @@ class ProPerf_Data_Collector {
 			// Hooks.
 			'hook_count'              => $metrics['hooks']['registered_count'],
 			// Database.
-			'db_total_size_bytes'     => $metrics['database']['total_size_bytes'],
+			'db_total_size_bytes'              => $metrics['database']['total_size_bytes'],
+			// WooCommerce orders.
+			'woo_order_items_size_bytes'        => $metrics['woo_orders']['order_items_size_bytes'],
+			'woo_order_itemmeta_size_bytes'     => $metrics['woo_orders']['order_itemmeta_size_bytes'],
+			'woo_oldest_order_age_days'         => $metrics['woo_orders']['oldest_order_age_days'],
+			'woo_archival_trigger'              => $metrics['woo_orders']['archival_trigger'] ? 1 : 0,
 		);
 	}
 }

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -137,13 +137,15 @@ class ProPerf_Data_Collector {
 			'SELECT table_name, ROUND(data_length + index_length) AS size_bytes
 			 FROM information_schema.tables
 			 WHERE table_schema = DATABASE()
-			 ORDER BY size_bytes DESC LIMIT 10'
+			 ORDER BY size_bytes DESC LIMIT 10',
+			ARRAY_A
 		);
 
 		$top_tables_map = array();
 		if ( $top_tables ) {
 			foreach ( $top_tables as $table ) {
-				$top_tables_map[ $table->table_name ] = intval( $table->size_bytes );
+				$name                    = $table['table_name'] ?? $table['TABLE_NAME'] ?? '';
+				$top_tables_map[ $name ] = intval( $table['size_bytes'] ?? $table['SIZE_BYTES'] ?? 0 );
 			}
 		}
 

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -75,8 +75,7 @@ class ProPerf_Data_Collector {
 	/**
 	 * Collect plugin metrics.
 	 *
-	 * Counts active and inactive plugins. Business value: every inactive plugin
-	 * is dead code loading on every request — costing page load time and conversions.
+	 * Counts active and inactive plugins installed on the site.
 	 *
 	 * @return array Plugin metrics.
 	 */
@@ -103,9 +102,7 @@ class ProPerf_Data_Collector {
 	/**
 	 * Collect hook metrics.
 	 *
-	 * Counts registered hooks via $wp_filter. Business value: hook count is a
-	 * direct indicator of plugin sprawl and backend execution complexity — MFM
-	 * had 344,000 hooks/page, translating directly to slow checkout.
+	 * Counts registered hooks via $wp_filter.
 	 *
 	 * @return array Hook metrics.
 	 */
@@ -123,10 +120,7 @@ class ProPerf_Data_Collector {
 	/**
 	 * Collect database table size metrics.
 	 *
-	 * Reports total DB size and top 10 tables by size. Business value: a bloated
-	 * database means slower queries, slower order processing, and higher hosting
-	 * costs — surfacing which tables are growing enables targeted cleanup before
-	 * the client notices slowness.
+	 * Reports total DB size and top 10 tables by size.
 	 *
 	 * @return array Database size metrics.
 	 */

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -20,7 +20,12 @@ class ProPerf_Data_Collector {
 	 * @return array Collected metrics.
 	 */
 	public function get_data() {
-		return $this->collect_autoloaded_options();
+		return array_merge(
+			$this->collect_autoloaded_options(),
+			$this->collect_plugin_metrics(),
+			$this->collect_hook_metrics(),
+			$this->collect_db_table_metrics()
+		);
 	}
 
 	/**
@@ -68,20 +73,118 @@ class ProPerf_Data_Collector {
 	}
 
 	/**
+	 * Collect plugin metrics.
+	 *
+	 * Counts active and inactive plugins. Business value: every inactive plugin
+	 * is dead code loading on every request — costing page load time and conversions.
+	 *
+	 * @return array Plugin metrics.
+	 */
+	public function collect_plugin_metrics() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$all_plugins    = get_plugins();
+		$active_plugins = get_option( 'active_plugins', array() );
+		$active_count   = count( $active_plugins );
+		$total_count    = count( $all_plugins );
+		$inactive_count = $total_count - $active_count;
+
+		return array(
+			'plugins' => array(
+				'active_count'   => $active_count,
+				'inactive_count' => $inactive_count,
+				'total_count'    => $total_count,
+			),
+		);
+	}
+
+	/**
+	 * Collect hook metrics.
+	 *
+	 * Counts registered hooks via $wp_filter. Business value: hook count is a
+	 * direct indicator of plugin sprawl and backend execution complexity — MFM
+	 * had 344,000 hooks/page, translating directly to slow checkout.
+	 *
+	 * @return array Hook metrics.
+	 */
+	public function collect_hook_metrics() {
+		global $wp_filter;
+		$hook_count = is_array( $wp_filter ) ? count( $wp_filter ) : 0;
+
+		return array(
+			'hooks' => array(
+				'registered_count' => $hook_count,
+			),
+		);
+	}
+
+	/**
+	 * Collect database table size metrics.
+	 *
+	 * Reports total DB size and top 10 tables by size. Business value: a bloated
+	 * database means slower queries, slower order processing, and higher hosting
+	 * costs — surfacing which tables are growing enables targeted cleanup before
+	 * the client notices slowness.
+	 *
+	 * @return array Database size metrics.
+	 */
+	public function collect_db_table_metrics() {
+		global $wpdb;
+
+		$total_size = $wpdb->get_var(
+			'SELECT SUM(data_length + index_length)
+			 FROM information_schema.tables
+			 WHERE table_schema = DATABASE()'
+		);
+
+		$top_tables = $wpdb->get_results(
+			'SELECT table_name, ROUND(data_length + index_length) AS size_bytes
+			 FROM information_schema.tables
+			 WHERE table_schema = DATABASE()
+			 ORDER BY size_bytes DESC LIMIT 10'
+		);
+
+		$top_tables_map = array();
+		if ( $top_tables ) {
+			foreach ( $top_tables as $table ) {
+				$top_tables_map[ $table->table_name ] = intval( $table->size_bytes );
+			}
+		}
+
+		return array(
+			'database' => array(
+				'total_size_bytes' => $total_size ? intval( $total_size ) : 0,
+				'top_tables'       => $top_tables_map,
+			),
+		);
+	}
+
+	/**
 	 * Format metrics for BigQuery.
 	 *
 	 * @param array $metrics Metrics data.
 	 * @return array Formatted data for BigQuery.
 	 */
 	public function format_for_bigquery( $metrics ) {
-		$site_url = get_site_url();
+		$site_url  = get_site_url();
 		$timestamp = gmdate( 'Y-m-d H:i:s' );
 
 		return array(
-			'timestamp_utc'          => $timestamp,
+			'timestamp_utc'           => $timestamp,
+			'site_url'                => $site_url,
+			// Autoload.
 			'autoloaded_option_count' => $metrics['autoloaded_option']['count'],
 			'autoloaded_option_size'  => $metrics['autoloaded_option']['size_bytes'],
-			'site_url'               => $site_url,
+			// Plugins.
+			'active_plugin_count'     => $metrics['plugins']['active_count'],
+			'inactive_plugin_count'   => $metrics['plugins']['inactive_count'],
+			'total_plugin_count'      => $metrics['plugins']['total_count'],
+			// Hooks.
+			'hook_count'              => $metrics['hooks']['registered_count'],
+			// Database.
+			'db_total_size_bytes'     => $metrics['database']['total_size_bytes'],
 		);
 	}
 }

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -135,7 +135,7 @@ class ProPerf_Data_Collector {
 		);
 
 		$top_tables = $wpdb->get_results(
-			'SELECT table_name, ROUND(data_length + index_length) AS size_bytes
+			'SELECT table_name AS tbl_name, ROUND(data_length + index_length) AS size_bytes
 			 FROM information_schema.tables
 			 WHERE table_schema = DATABASE()
 			 ORDER BY size_bytes DESC LIMIT 10',
@@ -145,8 +145,12 @@ class ProPerf_Data_Collector {
 		$top_tables_map = array();
 		if ( $top_tables ) {
 			foreach ( $top_tables as $table ) {
+<<<<<<< Updated upstream
 				$name                    = $table['table_name'] ?? $table['TABLE_NAME'] ?? '';
 				$top_tables_map[ $name ] = intval( $table['size_bytes'] ?? $table['SIZE_BYTES'] ?? 0 );
+=======
+				$top_tables_map[ $table->tbl_name ] = intval( $table->size_bytes );
+>>>>>>> Stashed changes
 			}
 		}
 

--- a/properf-wordpress-adapter.php
+++ b/properf-wordpress-adapter.php
@@ -215,8 +215,11 @@ function properf_render_dashboard() {
 		wp_die( 'Unauthorized' );
 	}
 
-	$metrics                = properf_get_live_data();
+	$metrics                 = properf_get_live_data();
 	$autoloaded_data_metrics = $metrics['autoloaded_option'];
+	$plugin_metrics          = $metrics['plugins'];
+	$hook_metrics            = $metrics['hooks'];
+	$db_metrics              = $metrics['database'];
 
 	$count         = $autoloaded_data_metrics['count'];
 	$size_bytes    = $autoloaded_data_metrics['size_bytes'];
@@ -267,16 +270,39 @@ function properf_render_dashboard() {
 				<tr>
 					<th><?php esc_html_e( 'Metric', 'properf' ); ?></th>
 					<th><?php esc_html_e( 'Value', 'properf' ); ?></th>
+					<th><?php esc_html_e( 'Target', 'properf' ); ?></th>
 				</tr>
 			</thead>
 			<tbody>
 				<tr>
 					<td><strong><?php esc_html_e( 'Autoloaded Option Count', 'properf' ); ?></strong></td>
 					<td><?php echo esc_html( number_format( $count ) ); ?></td>
+					<td>—</td>
 				</tr>
 				<tr>
 					<td><strong><?php esc_html_e( 'Autoloaded Option Size', 'properf' ); ?></strong></td>
 					<td><?php printf( '%.2f KB', $size_bytes / 1024 ); ?></td>
+					<td>&lt; 500 KB</td>
+				</tr>
+				<tr>
+					<td><strong><?php esc_html_e( 'Active Plugins', 'properf' ); ?></strong></td>
+					<td><?php echo esc_html( number_format( $plugin_metrics['active_count'] ) ); ?></td>
+					<td>&lt; 15</td>
+				</tr>
+				<tr>
+					<td><strong><?php esc_html_e( 'Inactive Plugins', 'properf' ); ?></strong></td>
+					<td><?php echo esc_html( number_format( $plugin_metrics['inactive_count'] ) ); ?></td>
+					<td>0</td>
+				</tr>
+				<tr>
+					<td><strong><?php esc_html_e( 'Registered Hooks', 'properf' ); ?></strong></td>
+					<td><?php echo esc_html( number_format( $hook_metrics['registered_count'] ) ); ?></td>
+					<td>&lt; 50,000</td>
+				</tr>
+				<tr>
+					<td><strong><?php esc_html_e( 'Total Database Size', 'properf' ); ?></strong></td>
+					<td><?php printf( '%.2f MB', $db_metrics['total_size_bytes'] / 1024 / 1024 ); ?></td>
+					<td>&lt; 10 GB</td>
 				</tr>
 			</tbody>
 		</table>
@@ -301,6 +327,28 @@ function properf_render_dashboard() {
 			</table>
 		<?php else : ?>
 			<p><?php esc_html_e( 'No autoloaded option keys found or an error occurred.', 'properf' ); ?></p>
+		<?php endif; ?>
+
+		<h2 style="margin-top: 30px;"><?php esc_html_e( 'Top 10 Database Tables by Size', 'properf' ); ?></h2>
+		<?php if ( ! empty( $db_metrics['top_tables'] ) ) : ?>
+			<table class="widefat striped">
+				<thead>
+					<tr>
+						<th><strong><?php esc_html_e( 'Table Name', 'properf' ); ?></strong></th>
+						<th><strong><?php esc_html_e( 'Size', 'properf' ); ?></strong></th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php foreach ( $db_metrics['top_tables'] as $table_name => $table_size ) : ?>
+						<tr>
+							<td><?php echo esc_html( $table_name ); ?></td>
+							<td><?php printf( '%.2f MB', $table_size / 1024 / 1024 ); ?></td>
+						</tr>
+					<?php endforeach; ?>
+				</tbody>
+			</table>
+		<?php else : ?>
+			<p><?php esc_html_e( 'No database table data found or an error occurred.', 'properf' ); ?></p>
 		<?php endif; ?>
 	</div>
 <?php
@@ -575,14 +623,28 @@ add_filter( 'wp_redirect', 'properf_settings_redirect' );
  * @return array Metrics data.
  */
 function properf_get_live_data() {
+	$empty_response = array(
+		'autoloaded_option' => array(
+			'count'         => 0,
+			'size_bytes'    => 0,
+			'top_size_keys' => array(),
+		),
+		'plugins'           => array(
+			'active_count'   => 0,
+			'inactive_count' => 0,
+			'total_count'    => 0,
+		),
+		'hooks'             => array(
+			'registered_count' => 0,
+		),
+		'database'          => array(
+			'total_size_bytes' => 0,
+			'top_tables'       => array(),
+		),
+	);
+
 	if ( ! class_exists( 'ProPerf_Data_Collector' ) ) {
-		return array(
-			'autoloaded_option' => array(
-				'count'         => 'Error: Collector Class Missing',
-				'size_bytes'    => 0,
-				'top_size_keys' => array(),
-			),
-		);
+		return $empty_response;
 	}
 
 	try {
@@ -590,12 +652,6 @@ function properf_get_live_data() {
 		return $collector->get_data();
 	} catch ( Exception $e ) {
 		error_log( 'ProPerf Error: ' . $e->getMessage() );
-		return array(
-			'autoloaded_option' => array(
-				'count'         => 'Error: ' . $e->getMessage(),
-				'size_bytes'    => 0,
-				'top_size_keys' => array(),
-			),
-		);
+		return $empty_response;
 	}
 }

--- a/properf-wordpress-adapter.php
+++ b/properf-wordpress-adapter.php
@@ -220,6 +220,7 @@ function properf_render_dashboard() {
 	$plugin_metrics          = $metrics['plugins'];
 	$hook_metrics            = $metrics['hooks'];
 	$db_metrics              = $metrics['database'];
+	$woo_metrics             = $metrics['woo_orders'];
 
 	$count         = $autoloaded_data_metrics['count'];
 	$size_bytes    = $autoloaded_data_metrics['size_bytes'];
@@ -349,6 +350,49 @@ function properf_render_dashboard() {
 			</table>
 		<?php else : ?>
 			<p><?php esc_html_e( 'No database table data found or an error occurred.', 'properf' ); ?></p>
+		<?php endif; ?>
+
+		<h2 style="margin-top: 30px;"><?php esc_html_e( 'WooCommerce Order Metrics', 'properf' ); ?></h2>
+		<?php if ( ! $woo_metrics['woo_active'] ) : ?>
+			<p><?php esc_html_e( 'WooCommerce is not active on this site.', 'properf' ); ?></p>
+		<?php else : ?>
+			<table class="widefat striped">
+				<thead>
+					<tr>
+						<th><?php esc_html_e( 'Metric', 'properf' ); ?></th>
+						<th><?php esc_html_e( 'Value', 'properf' ); ?></th>
+						<th><?php esc_html_e( 'Target', 'properf' ); ?></th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><strong><?php esc_html_e( 'Order Items Table Size', 'properf' ); ?></strong></td>
+						<td><?php printf( '%.2f MB', $woo_metrics['order_items_size_bytes'] / 1024 / 1024 ); ?></td>
+						<td>—</td>
+					</tr>
+					<tr>
+						<td><strong><?php esc_html_e( 'Order Itemmeta Table Size', 'properf' ); ?></strong></td>
+						<td><?php printf( '%.2f MB', $woo_metrics['order_itemmeta_size_bytes'] / 1024 / 1024 ); ?></td>
+						<td>—</td>
+					</tr>
+					<tr>
+						<td><strong><?php esc_html_e( 'Oldest Order Age', 'properf' ); ?></strong></td>
+						<td><?php echo esc_html( number_format( $woo_metrics['oldest_order_age_days'] ) ) . ' days'; ?></td>
+						<td>&lt; 365 days</td>
+					</tr>
+					<tr>
+						<td><strong><?php esc_html_e( 'Archival Trigger', 'properf' ); ?></strong></td>
+						<td>
+							<?php if ( $woo_metrics['archival_trigger'] ) : ?>
+								<span style="color: #d63638; font-weight: bold;"><?php esc_html_e( 'Yes — orders older than 1 year detected', 'properf' ); ?></span>
+							<?php else : ?>
+								<span style="color: #00a32a;"><?php esc_html_e( 'No', 'properf' ); ?></span>
+							<?php endif; ?>
+						</td>
+						<td><?php esc_html_e( 'No', 'properf' ); ?></td>
+					</tr>
+				</tbody>
+			</table>
 		<?php endif; ?>
 	</div>
 <?php


### PR DESCRIPTION
Extends `ProPerf_Data_Collector` to collect server-side metrics that GTmetrix cannot see, closing audit checklist gaps for sections 2, 3, and 4.

## What this PR adds

- **Plugin layer** — active, inactive, and total plugin count via `get_plugins()`
- **Hook count** — total registered WordPress hooks via `wp_filter` count
- **Database** — total DB size via `information_schema`
- **Top 10 tables by size** — visible in the Admin Panel dashboard
- **WooCommerce order metrics** — visible in the Admin Panel dashboard with the following columns and inferences:
  - Order items table size and order itemmeta table size
  - Oldest order age — shows how long the oldest order has been sitting in the database
  - Archival trigger — displays a target of "No"; shown in **red** with "Yes — orders older than 1 year detected" if orders older than 365 days exist, or **green** "No" if all orders are within range

## Technical changes

- New collector methods in `ProPerf_Data_Collector`: plugin metrics, hook metrics, DB table metrics, and WooCommerce order metrics
- `format_for_bigquery()` updated with new fields for all of the above
- BigQuery schema updated with corresponding column definitions
- Admin dashboard updated to display all new metrics with targets alongside values; WooCommerce section is only shown when WooCommerce is active