### PR TITLE
Feat: Add build script for distributable plugin ZIP

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+PLUGIN_SLUG="performance-adapter-wp"
+MAIN_FILE="properf-wordpress-adapter.php"
+
+# Extract version from plugin header
+VERSION=$(grep -m1 "Version:" "$MAIN_FILE" | awk '{print $3}')
+
+if [ -z "$VERSION" ]; then
+  echo "Error: Could not read version from $MAIN_FILE"
+  exit 1
+fi
+
+BUILD_DIR="build/${PLUGIN_SLUG}"
+ZIP_NAME="${PLUGIN_SLUG}-${VERSION}.zip"
+
+echo "Building ${PLUGIN_SLUG} v${VERSION}..."
+
+# Clean previous build
+rm -rf build
+mkdir -p "$BUILD_DIR"
+
+# Install production dependencies
+composer install --no-dev --optimize-autoloader --quiet
+
+# Copy plugin files
+cp "$MAIN_FILE" "$BUILD_DIR/"
+cp composer.json composer.lock "$BUILD_DIR/"
+cp -r includes vendor "$BUILD_DIR/"
+
+# Create ZIP
+cd build
+zip -rq "$ZIP_NAME" "$PLUGIN_SLUG"
+cd ..
+
+echo "Done: build/${ZIP_NAME}"


### PR DESCRIPTION
## Summary

Adds a build script (`bin/build.sh`) that generates a self-contained, ready-to-install plugin ZIP — including Composer dependencies (`vendor/`).

Previously, sharing just the GitHub link required the person deploying to run `composer install` on the server, which caused the "Google SDK not loaded" error.

## Usage

```bash
bash bin/build.sh
```

Outputs: `build/performance-adapter-wp-{version}.zip`

## What's included in the ZIP

- Plugin main file (`properf-wordpress-adapter.php`)
- `includes/` directory
- `vendor/` (production Composer dependencies, installed with `--no-dev`)
- `composer.json` and `composer.lock`

## What's excluded

- `.git`, `.gitignore`, dev dependencies, `build/` directory itself

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJ4FmXXzuRwyQ9ZA89UjeJ)_