### PR TITLE
Bump plugin version to 1.0.3

### DIFF
--- a/properf-wordpress-adapter.php
+++ b/properf-wordpress-adapter.php
@@ -3,7 +3,7 @@
  * Plugin Name: ProPerf WordPress Adapter
  * Plugin URI: https://coloredcow.com
  * Description: Collects and displays database health metrics (autoloaded options)
- * Version: 1.0.2
+ * Version: 1.0.3
  * Author: ColoredCow
  * License: GPL v2 or later
  *
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'PROPERF_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PROPERF_URL', plugin_dir_url( __FILE__ ) );
-define( 'PROPERF_VERSION', '1.0.2' );
+define( 'PROPERF_VERSION', '1.0.3' );
 
 require_once PROPERF_DIR . 'includes/class-data-collector.php';
 


### PR DESCRIPTION
## Summary

- Bumps plugin version from `1.0.2` → `1.0.3` in the plugin header and `PROPERF_VERSION` constant

## Changes

- `properf-wordpress-adapter.php`: Updated `Version:` header and `define( 'PROPERF_VERSION', ... )` to `1.0.3`

## Test plan

- [ ] Activate plugin on a WordPress site and confirm WordPress admin shows version `1.0.3` under Plugins list
