### PR TITLE
Cache WooCommerce metrics snapshot on dashboard load

### DIFF
--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -19,6 +19,8 @@ class ProPerf_Admin_Settings {
 	 */
 	public static function register_persistent_hooks() {
 		add_action( 'update_option_properf_last_archival_date', array( __CLASS__, 'reset_qet_on_archival_change' ), 10, 2 );
+		add_action( 'update_option_properf_last_archival_date', array( __CLASS__, 'bust_woo_metrics_cache' ) );
+		add_action( 'update_option_properf_archival_threshold_years', array( __CLASS__, 'bust_woo_metrics_cache' ) );
 	}
 
 	/**
@@ -40,6 +42,13 @@ class ProPerf_Admin_Settings {
 			update_option( 'properf_qet_history', array(), false );
 			delete_option( 'properf_baseline_qet_ms' );
 		}
+	}
+
+	/**
+	 * Invalidate the cached WooCommerce metrics snapshot when settings that affect it change.
+	 */
+	public static function bust_woo_metrics_cache() {
+		delete_transient( 'properf_woo_metrics_snapshot' );
 	}
 
 	/**

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -19,10 +19,10 @@ class ProPerf_Admin_Settings {
 	 */
 	public static function register_persistent_hooks() {
 		add_action( 'update_option_properf_last_archival_date', array( __CLASS__, 'reset_qet_on_archival_change' ), 10, 2 );
-		add_action( 'update_option_properf_last_archival_date', array( __CLASS__, 'bust_woo_metrics_cache' ) );
-		add_action( 'add_option_properf_last_archival_date', array( __CLASS__, 'bust_woo_metrics_cache' ) );
-		add_action( 'update_option_properf_archival_threshold_years', array( __CLASS__, 'bust_woo_metrics_cache' ) );
-		add_action( 'add_option_properf_archival_threshold_years', array( __CLASS__, 'bust_woo_metrics_cache' ) );
+		add_action( 'update_option_properf_last_archival_date', array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
+		add_action( 'add_option_properf_last_archival_date', array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
+		add_action( 'update_option_properf_archival_threshold_years', array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
+		add_action( 'add_option_properf_archival_threshold_years', array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
 	}
 
 	/**
@@ -44,13 +44,6 @@ class ProPerf_Admin_Settings {
 			update_option( 'properf_qet_history', array(), false );
 			delete_option( 'properf_baseline_qet_ms' );
 		}
-	}
-
-	/**
-	 * Invalidate the cached WooCommerce metrics snapshot when settings that affect it change.
-	 */
-	public static function bust_woo_metrics_cache() {
-		delete_transient( 'properf_woo_metrics_snapshot' );
 	}
 
 	/**

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -20,7 +20,9 @@ class ProPerf_Admin_Settings {
 	public static function register_persistent_hooks() {
 		add_action( 'update_option_properf_last_archival_date', array( __CLASS__, 'reset_qet_on_archival_change' ), 10, 2 );
 		add_action( 'update_option_properf_last_archival_date', array( __CLASS__, 'bust_woo_metrics_cache' ) );
+		add_action( 'add_option_properf_last_archival_date', array( __CLASS__, 'bust_woo_metrics_cache' ) );
 		add_action( 'update_option_properf_archival_threshold_years', array( __CLASS__, 'bust_woo_metrics_cache' ) );
+		add_action( 'add_option_properf_archival_threshold_years', array( __CLASS__, 'bust_woo_metrics_cache' ) );
 	}
 
 	/**

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -270,16 +270,20 @@ class ProPerf_Data_Collector {
 	/**
 	 * Refresh the baseline fields in the cached snapshot after a new QET reading is recorded.
 	 * Keeps the rest of the snapshot intact so the dashboard reflects the post-push baseline immediately.
+	 * Returns the updated baseline array, or null if no snapshot was cached.
+	 *
+	 * @return array|null {ms: int|null, source: string|null}, or null if no cached snapshot exists.
 	 */
 	private function refresh_cached_baseline() {
 		$cached = get_transient( 'properf_woo_metrics_snapshot' );
 		if ( false === $cached ) {
-			return;
+			return null;
 		}
-		$baseline                          = $this->get_baseline_qet( $cached['woo']['last_archival_date'] );
+		$baseline = $this->get_baseline_qet( $cached['woo']['last_archival_date'] );
 		$cached['woo']['baseline_qet_ms']     = $baseline['ms'];
 		$cached['woo']['baseline_qet_source'] = $baseline['source'];
 		set_transient( 'properf_woo_metrics_snapshot', $cached, HOUR_IN_SECONDS );
+		return $baseline;
 	}
 
 	/**
@@ -301,7 +305,11 @@ class ProPerf_Data_Collector {
 		}
 
 		$this->record_qet_reading( $metrics['woo']['query_execution_ms'] );
-		$this->refresh_cached_baseline();
+		$baseline = $this->refresh_cached_baseline();
+		if ( null !== $baseline ) {
+			$metrics['woo']['baseline_qet_ms']     = $baseline['ms'];
+			$metrics['woo']['baseline_qet_source'] = $baseline['source'];
+		}
 		$bq_client = new ProPerf_BigQuery_Client();
 		$success   = $bq_client->push_metrics( $metrics );
 

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -95,7 +95,7 @@ class ProPerf_Data_Collector {
 			);
 		}
 
-		// Cache is invalidated by collect_and_push() and by settings changes via ProPerf_Admin_Settings::bust_woo_metrics_cache().
+		// Cached for 1 hour; invalidated on push and on relevant settings changes.
 		$cached = get_transient( 'properf_woo_metrics_snapshot' );
 		if ( false !== $cached ) {
 			return $cached;
@@ -277,7 +277,7 @@ class ProPerf_Data_Collector {
 			return;
 		}
 		$baseline                          = $this->get_baseline_qet( $cached['woo']['last_archival_date'] );
-		$cached['woo']['baseline_qet_ms']  = $baseline['ms'];
+		$cached['woo']['baseline_qet_ms']     = $baseline['ms'];
 		$cached['woo']['baseline_qet_source'] = $baseline['source'];
 		set_transient( 'properf_woo_metrics_snapshot', $cached, HOUR_IN_SECONDS );
 	}

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -95,6 +95,11 @@ class ProPerf_Data_Collector {
 			);
 		}
 
+		$cached = get_transient( 'properf_woo_metrics_snapshot' );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
 		global $wpdb;
 
 		$db_name  = DB_NAME;
@@ -196,7 +201,7 @@ class ProPerf_Data_Collector {
 		$last_archival_date = get_option( 'properf_last_archival_date', null ) ?: null;
 		$baseline           = $this->get_baseline_qet( $last_archival_date );
 
-		return array(
+		$result = array(
 			'woo' => array(
 				'order_items_size_mb'    => $items_size ? round( floatval( $items_size ), 4 ) : 0.0,
 				'order_itemmeta_size_mb' => $itemmeta_size ? round( floatval( $itemmeta_size ), 4 ) : 0.0,
@@ -211,6 +216,10 @@ class ProPerf_Data_Collector {
 				'baseline_qet_source'    => $baseline['source'],
 			),
 		);
+
+		set_transient( 'properf_woo_metrics_snapshot', $result, HOUR_IN_SECONDS );
+
+		return $result;
 	}
 
 	/**
@@ -265,6 +274,8 @@ class ProPerf_Data_Collector {
 	 */
 	public function collect_and_push() {
 		require_once PROPERF_DIR . 'includes/class-bigquery-client.php';
+
+		delete_transient( 'properf_woo_metrics_snapshot' );
 
 		try {
 			$metrics = $this->get_data();

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -14,6 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class ProPerf_Data_Collector {
 
+	const WOO_METRICS_CACHE_KEY = 'properf_woo_metrics_snapshot';
+
 	/**
 	 * Get collected data.
 	 *
@@ -96,7 +98,7 @@ class ProPerf_Data_Collector {
 		}
 
 		// Cached for 1 hour; invalidated on push and on relevant settings changes.
-		$cached = get_transient( 'properf_woo_metrics_snapshot' );
+		$cached = get_transient( self::WOO_METRICS_CACHE_KEY );
 		if ( false !== $cached ) {
 			return $cached;
 		}
@@ -218,7 +220,7 @@ class ProPerf_Data_Collector {
 			),
 		);
 
-		set_transient( 'properf_woo_metrics_snapshot', $result, HOUR_IN_SECONDS );
+		set_transient( self::WOO_METRICS_CACHE_KEY, $result, HOUR_IN_SECONDS );
 
 		return $result;
 	}
@@ -272,17 +274,22 @@ class ProPerf_Data_Collector {
 	 * Keeps the rest of the snapshot intact so the dashboard reflects the post-push baseline immediately.
 	 * Returns the updated baseline array, or null if no snapshot was cached.
 	 *
+	 * Most calls are no-ops (locked baseline returns the same value either way).
+	 * Matters at lock-in (10th post-archival reading) and when the lowest-10
+	 * fallback shifts down — both move the baseline in ways the just-computed
+	 * snapshot won't reflect.
+	 *
 	 * @return array|null {ms: int|null, source: string|null}, or null if no cached snapshot exists.
 	 */
 	private function refresh_cached_baseline() {
-		$cached = get_transient( 'properf_woo_metrics_snapshot' );
+		$cached = get_transient( self::WOO_METRICS_CACHE_KEY );
 		if ( false === $cached ) {
 			return null;
 		}
 		$baseline = $this->get_baseline_qet( $cached['woo']['last_archival_date'] );
 		$cached['woo']['baseline_qet_ms']     = $baseline['ms'];
 		$cached['woo']['baseline_qet_source'] = $baseline['source'];
-		set_transient( 'properf_woo_metrics_snapshot', $cached, HOUR_IN_SECONDS );
+		set_transient( self::WOO_METRICS_CACHE_KEY, $cached, HOUR_IN_SECONDS );
 		return $baseline;
 	}
 
@@ -295,7 +302,7 @@ class ProPerf_Data_Collector {
 	public function collect_and_push() {
 		require_once PROPERF_DIR . 'includes/class-bigquery-client.php';
 
-		delete_transient( 'properf_woo_metrics_snapshot' );
+		delete_transient( self::WOO_METRICS_CACHE_KEY );
 
 		try {
 			$metrics = $this->get_data();
@@ -386,6 +393,14 @@ class ProPerf_Data_Collector {
 			'ms'     => (int) round( array_sum( $lowest ) / count( $lowest ) ),
 			'source' => 'lowest-10:' . count( $lowest ),
 		);
+	}
+
+	/**
+	 * Delete the cached WooCommerce metrics snapshot.
+	 * Called by settings hooks when archival date or threshold changes.
+	 */
+	public static function bust_metrics_cache() {
+		delete_transient( self::WOO_METRICS_CACHE_KEY );
 	}
 
 	/**

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -95,6 +95,7 @@ class ProPerf_Data_Collector {
 			);
 		}
 
+		// Cache is invalidated by collect_and_push() and by settings changes via ProPerf_Admin_Settings::bust_woo_metrics_cache().
 		$cached = get_transient( 'properf_woo_metrics_snapshot' );
 		if ( false !== $cached ) {
 			return $cached;
@@ -267,6 +268,21 @@ class ProPerf_Data_Collector {
 	}
 
 	/**
+	 * Refresh the baseline fields in the cached snapshot after a new QET reading is recorded.
+	 * Keeps the rest of the snapshot intact so the dashboard reflects the post-push baseline immediately.
+	 */
+	private function refresh_cached_baseline() {
+		$cached = get_transient( 'properf_woo_metrics_snapshot' );
+		if ( false === $cached ) {
+			return;
+		}
+		$baseline                          = $this->get_baseline_qet( $cached['woo']['last_archival_date'] );
+		$cached['woo']['baseline_qet_ms']  = $baseline['ms'];
+		$cached['woo']['baseline_qet_source'] = $baseline['source'];
+		set_transient( 'properf_woo_metrics_snapshot', $cached, HOUR_IN_SECONDS );
+	}
+
+	/**
 	 * Collect metrics, record QET, push to BigQuery, and persist sync status.
 	 * Returns result so callers can handle their own notifications.
 	 *
@@ -285,6 +301,7 @@ class ProPerf_Data_Collector {
 		}
 
 		$this->record_qet_reading( $metrics['woo']['query_execution_ms'] );
+		$this->refresh_cached_baseline();
 		$bq_client = new ProPerf_BigQuery_Client();
 		$success   = $bq_client->push_metrics( $metrics );
 


### PR DESCRIPTION
Closes #24

## Problem

Every ProPerf dashboard load re-ran the full set of WooCommerce order queries — table size lookups, date range scans, COUNT queries, and the QET JOIN — even when the data hadn't changed. On large databases this adds unnecessary DB load on every page view.

## Solution

Cache the output of `collect_woo_order_metrics()` as a 1-hour WordPress transient. The dashboard hits the cache on repeated loads; only pushes (manual or cron) run live queries.

## Changes

**`includes/class-data-collector.php`**
- Add `WOO_METRICS_CACHE_KEY` constant as the single source of truth for the transient key.
- `collect_woo_order_metrics()`: return cached transient on hit; compute and cache on miss (1-hour TTL via `HOUR_IN_SECONDS`).
- `collect_and_push()`: delete transient before collecting so pushes always use fresh data; after `record_qet_reading()`, call `refresh_cached_baseline()` and update `$metrics` before the BigQuery push to keep the BigQuery row and dashboard baseline consistent.
- Add `refresh_cached_baseline()` (private): after a push records a new QET reading, rewrites only the baseline fields in the cached snapshot so the dashboard immediately reflects the post-push baseline without expiring the rest of the snapshot.
- Add `bust_metrics_cache()` (public static): owns the `delete_transient` call so settings hooks delegate to the class that owns the cache.

**`includes/class-admin-settings.php`**
- `register_persistent_hooks()`: add `update_option_` and `add_option_` hooks for both `properf_last_archival_date` and `properf_archival_threshold_years` to call `ProPerf_Data_Collector::bust_metrics_cache()`. Both hooks are needed because `update_option_` does not fire on the first-ever save of an option.