### PR TITLE
Add server-side metrics: plugin count, hook count, DB table sizes

### DIFF
--- a/includes/class-admin-dashboard.php
+++ b/includes/class-admin-dashboard.php
@@ -191,7 +191,7 @@ class ProPerf_Admin_Dashboard {
 			$last_pushed_display = __( 'Never', 'properf' );
 		}
 
-		$table_name_warning = get_option( 'properf_table_name_encoding_warning' );
+		$table_name_warning = $server_metrics['table_name_warning'] ?? '';
 		?>
 		<div class="wrap">
 			<h1><?php esc_html_e( 'ProPerf WordPress Metrics', 'properf' ); ?></h1>

--- a/includes/class-admin-dashboard.php
+++ b/includes/class-admin-dashboard.php
@@ -348,7 +348,7 @@ class ProPerf_Admin_Dashboard {
 			</table>
 
 			<?php if ( ! empty( $server_metrics['db_table_sizes'] ) ) : ?>
-				<h2 class="properf-section-heading"><?php esc_html_e( 'Database Tables by Size', 'properf' ); ?></h2>
+				<h2 class="properf-section-heading"><?php esc_html_e( 'Top 10 Database Tables by Size', 'properf' ); ?></h2>
 				<table class="widefat striped">
 					<thead>
 						<tr>
@@ -357,7 +357,7 @@ class ProPerf_Admin_Dashboard {
 						</tr>
 					</thead>
 					<tbody>
-						<?php foreach ( $server_metrics['db_table_sizes'] as $table_name => $size_mb ) : ?>
+						<?php foreach ( array_slice( $server_metrics['db_table_sizes'], 0, 10, true ) as $table_name => $size_mb ) : ?>
 							<tr>
 								<td><?php echo esc_html( $table_name ); ?></td>
 								<td><?php echo esc_html( number_format( $size_mb, 2 ) . ' MB' ); ?></td>

--- a/includes/class-admin-dashboard.php
+++ b/includes/class-admin-dashboard.php
@@ -154,13 +154,13 @@ class ProPerf_Admin_Dashboard {
 		$server_metrics = $metrics['server'];
 		$woo_metrics    = $metrics['woo'];
 		$oldest_date    = $woo_metrics['oldest_order_date'];
-		$latest_date = $woo_metrics['latest_order_date'];
+		$latest_date    = $woo_metrics['latest_order_date'];
 
 		$orders_older_than_threshold = $woo_metrics['orders_older_than_threshold'];
 		$total_orders                = $woo_metrics['total_orders'];
 		$threshold_years             = $woo_metrics['threshold_years'];
 		$last_archival_date          = $woo_metrics['last_archival_date'];
-		$baseline_qet_ms        = $woo_metrics['baseline_qet_ms'];
+		$baseline_qet_ms             = $woo_metrics['baseline_qet_ms'];
 		$alert_threshold_mb     = $woo_metrics['alert_threshold_mb'] ?? null;
 		$archival_signal_active = $woo_metrics['archival_signal_active'] ?? false;
 

--- a/includes/class-admin-dashboard.php
+++ b/includes/class-admin-dashboard.php
@@ -203,7 +203,7 @@ class ProPerf_Admin_Dashboard {
 				<input type="submit" name="properf_push_to_bq" class="button button-primary" value="<?php esc_attr_e( 'Push to BigQuery', 'properf' ); ?>">
 			</form>
 
-			<?php if ( function_exists( 'WC' ) && null !== $alert_threshold_mb ) : ?>
+			<?php if ( function_exists( 'WC' ) && null !== $alert_threshold_mb && null !== $woo_metrics['order_itemmeta_size_mb'] ) : ?>
 				<div class="properf-signal-banner <?php echo esc_attr( $archival_signal_active ? 'properf-signal-banner--alert' : 'properf-signal-banner--ok' ); ?>">
 					<?php if ( $archival_signal_active ) : ?>
 						<strong class="properf-signal-banner__title--alert">&#9888; <?php esc_html_e( 'Archival recommended', 'properf' ); ?></strong>
@@ -273,7 +273,7 @@ class ProPerf_Admin_Dashboard {
 						</tr>
 						<tr>
 							<td><strong><?php esc_html_e( 'Order Itemmeta Table Size', 'properf' ); ?></strong></td>
-							<td><?php echo esc_html( number_format( $woo_metrics['order_itemmeta_size_mb'], 2 ) . ' MB' ); ?></td>
+							<td><?php echo esc_html( null !== $woo_metrics['order_itemmeta_size_mb'] ? number_format( $woo_metrics['order_itemmeta_size_mb'], 2 ) . ' MB' : '—' ); ?></td>
 						</tr>
 						<tr>
 							<td><strong><?php esc_html_e( 'Oldest Order Date', 'properf' ); ?></strong></td>

--- a/includes/class-admin-dashboard.php
+++ b/includes/class-admin-dashboard.php
@@ -190,6 +190,8 @@ class ProPerf_Admin_Dashboard {
 		} else {
 			$last_pushed_display = __( 'Never', 'properf' );
 		}
+
+		$table_name_warning = get_option( 'properf_table_name_encoding_warning' );
 		?>
 		<div class="wrap">
 			<h1><?php esc_html_e( 'ProPerf WordPress Metrics', 'properf' ); ?></h1>
@@ -198,10 +200,7 @@ class ProPerf_Admin_Dashboard {
 
 			<?php settings_errors( 'properf_messages' ); ?>
 
-			<?php
-			$table_name_warning = get_option( 'properf_table_name_encoding_warning' );
-			if ( $table_name_warning ) :
-				?>
+			<?php if ( $table_name_warning ) : ?>
 				<div class="notice notice-warning">
 					<p>
 						<strong><?php esc_html_e( 'ProPerf Warning:', 'properf' ); ?></strong>

--- a/includes/class-admin-dashboard.php
+++ b/includes/class-admin-dashboard.php
@@ -198,6 +198,26 @@ class ProPerf_Admin_Dashboard {
 
 			<?php settings_errors( 'properf_messages' ); ?>
 
+			<?php
+			$table_name_warning = get_option( 'properf_table_name_encoding_warning' );
+			if ( $table_name_warning ) :
+				?>
+				<div class="notice notice-warning">
+					<p>
+						<strong><?php esc_html_e( 'ProPerf Warning:', 'properf' ); ?></strong>
+						<?php
+						echo esc_html(
+							sprintf(
+								/* translators: %s: date and time the issue was last detected */
+								__( 'One or more database table names contain special characters that cannot be encoded (detected %s). Those table names have been sanitized before sending to BigQuery. Remove any non-standard characters from affected table names to resolve this.', 'properf' ),
+								$table_name_warning
+							)
+						);
+						?>
+					</p>
+				</div>
+			<?php endif; ?>
+
 			<form method="post" class="properf-push-form">
 				<?php wp_nonce_field( 'properf_push_action', 'properf_push_nonce' ); ?>
 				<input type="submit" name="properf_push_to_bq" class="button button-primary" value="<?php esc_attr_e( 'Push to BigQuery', 'properf' ); ?>">

--- a/includes/class-admin-dashboard.php
+++ b/includes/class-admin-dashboard.php
@@ -151,8 +151,9 @@ class ProPerf_Admin_Dashboard {
 		$size_bytes     = $autoloaded_data_metrics['size_bytes'];
 		$top_size_keys  = $autoloaded_data_metrics['top_size_keys'];
 
-		$woo_metrics = $metrics['woo'];
-		$oldest_date = $woo_metrics['oldest_order_date'];
+		$server_metrics = $metrics['server'];
+		$woo_metrics    = $metrics['woo'];
+		$oldest_date    = $woo_metrics['oldest_order_date'];
 		$latest_date = $woo_metrics['latest_order_date'];
 
 		$orders_older_than_threshold = $woo_metrics['orders_older_than_threshold'];
@@ -316,6 +317,54 @@ class ProPerf_Admin_Dashboard {
 				</table>
 			<?php else : ?>
 				<p><?php esc_html_e( 'WooCommerce is not active on this site.', 'properf' ); ?></p>
+			<?php endif; ?>
+
+			<h2 class="properf-section-heading"><?php esc_html_e( 'Server Metrics', 'properf' ); ?></h2>
+			<table class="widefat striped">
+				<thead>
+					<tr>
+						<th><?php esc_html_e( 'Metric', 'properf' ); ?></th>
+						<th><?php esc_html_e( 'Value', 'properf' ); ?></th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td><strong><?php esc_html_e( 'Active Plugins', 'properf' ); ?></strong></td>
+						<td><?php echo esc_html( number_format( $server_metrics['active_plugin_count'] ) ); ?></td>
+					</tr>
+					<tr>
+						<td><strong><?php esc_html_e( 'Inactive Plugins', 'properf' ); ?></strong></td>
+						<td><?php echo esc_html( number_format( $server_metrics['inactive_plugin_count'] ) ); ?></td>
+					</tr>
+					<tr>
+						<td><strong><?php esc_html_e( 'Registered Hook Callbacks', 'properf' ); ?></strong></td>
+						<td><?php echo esc_html( number_format( $server_metrics['hook_count'] ) ); ?></td>
+					</tr>
+					<tr>
+						<td><strong><?php esc_html_e( 'Total Database Size', 'properf' ); ?></strong></td>
+						<td><?php echo esc_html( number_format( $server_metrics['total_db_size_mb'], 2 ) . ' MB' ); ?></td>
+					</tr>
+				</tbody>
+			</table>
+
+			<?php if ( ! empty( $server_metrics['db_table_sizes'] ) ) : ?>
+				<h2 class="properf-section-heading"><?php esc_html_e( 'Database Tables by Size', 'properf' ); ?></h2>
+				<table class="widefat striped">
+					<thead>
+						<tr>
+							<th><?php esc_html_e( 'Table', 'properf' ); ?></th>
+							<th><?php esc_html_e( 'Size', 'properf' ); ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php foreach ( $server_metrics['db_table_sizes'] as $table_name => $size_mb ) : ?>
+							<tr>
+								<td><?php echo esc_html( $table_name ); ?></td>
+								<td><?php echo esc_html( number_format( $size_mb, 2 ) . ' MB' ); ?></td>
+							</tr>
+						<?php endforeach; ?>
+					</tbody>
+				</table>
 			<?php endif; ?>
 		</div>
 		<?php

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -31,10 +31,30 @@ class ProPerf_Admin_Settings {
 		add_action( 'update_option_properf_order_itemmeta_db_alert_threshold', array( 'ProPerf_Data_Collector', 'bust_woo_metrics_cache' ) );
 		add_action( 'add_option_properf_order_itemmeta_db_alert_threshold', array( 'ProPerf_Data_Collector', 'bust_woo_metrics_cache' ) );
 		add_action( 'delete_option_properf_order_itemmeta_db_alert_threshold', array( 'ProPerf_Data_Collector', 'bust_woo_metrics_cache' ) );
-		add_action( 'activated_plugin',   array( 'ProPerf_Data_Collector', 'bust_server_metrics_cache' ) );
+		add_action( 'activated_plugin',   array( 'ProPerf_Data_Collector', 'bust_plugin_metrics_cache' ) );
 		add_action( 'activated_plugin',   array( 'ProPerf_Data_Collector', 'bust_autoload_metrics_cache' ) );
-		add_action( 'deactivated_plugin', array( 'ProPerf_Data_Collector', 'bust_server_metrics_cache' ) );
+		add_action( 'deactivated_plugin', array( 'ProPerf_Data_Collector', 'bust_plugin_metrics_cache' ) );
 		add_action( 'deactivated_plugin', array( 'ProPerf_Data_Collector', 'bust_autoload_metrics_cache' ) );
+		add_action( 'deleted_plugin',     array( 'ProPerf_Data_Collector', 'bust_plugin_metrics_cache' ) );
+		add_action( 'deleted_plugin',     array( 'ProPerf_Data_Collector', 'bust_autoload_metrics_cache' ) );
+		add_action( 'upgrader_process_complete', array( __CLASS__, 'bust_plugin_cache_on_install' ), 10, 2 );
+	}
+
+	/**
+	 * Bust plugin/autoload caches when a new plugin is installed (whether or not
+	 * it's then activated) — plugin count and autoload footprint can change
+	 * immediately on install, before any activated_plugin hook would fire.
+	 *
+	 * @param WP_Upgrader $upgrader   Unused.
+	 * @param array       $hook_extra Contains 'type' and 'action' for this upgrader run.
+	 */
+	public static function bust_plugin_cache_on_install( $upgrader, $hook_extra ) {
+		if ( isset( $hook_extra['type'], $hook_extra['action'] )
+			&& 'plugin' === $hook_extra['type']
+			&& 'install' === $hook_extra['action'] ) {
+			ProPerf_Data_Collector::bust_plugin_metrics_cache();
+			ProPerf_Data_Collector::bust_autoload_metrics_cache();
+		}
 	}
 
 	/**
@@ -444,11 +464,11 @@ class ProPerf_Admin_Settings {
 		$suggestion_notice = '';
 
 		if ( '' === $stored_mb ) {
-			$snapshot = get_transient( ProPerf_Data_Collector::WOO_METRICS_CACHE_KEY );
-			if ( false === $snapshot && function_exists( 'WC' ) && class_exists( 'ProPerf_Data_Collector' ) ) {
-				$snapshot = ( new ProPerf_Data_Collector() )->collect_woo_order_metrics();
-				set_transient( ProPerf_Data_Collector::WOO_METRICS_CACHE_KEY, $snapshot, HOUR_IN_SECONDS );
-			}
+			// collect_woo_order_metrics() already caches its own result — no need
+			// to wrap it in a second get_transient()/set_transient() pair here.
+			$snapshot = ( function_exists( 'WC' ) && class_exists( 'ProPerf_Data_Collector' ) )
+				? ( new ProPerf_Data_Collector() )->collect_woo_order_metrics()
+				: false;
 			$woo = isset( $snapshot['woo'] ) ? $snapshot['woo'] : null;
 
 			if ( $woo && ! empty( $woo['total_orders'] ) && $woo['total_orders'] > 0 && ! empty( $woo['orders_older_than_threshold'] ) && $woo['orders_older_than_threshold'] > 0 ) {

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -443,10 +443,10 @@ class ProPerf_Admin_Settings {
 		$suggestion_notice = '';
 
 		if ( '' === $stored_mb ) {
-			$snapshot = get_transient( 'properf_woo_metrics_snapshot' );
+			$snapshot = get_transient( ProPerf_Data_Collector::WOO_METRICS_CACHE_KEY );
 			if ( false === $snapshot && function_exists( 'WC' ) && class_exists( 'ProPerf_Data_Collector' ) ) {
 				$snapshot = ( new ProPerf_Data_Collector() )->collect_woo_order_metrics();
-				set_transient( 'properf_woo_metrics_snapshot', $snapshot, HOUR_IN_SECONDS );
+				set_transient( ProPerf_Data_Collector::WOO_METRICS_CACHE_KEY, $snapshot, HOUR_IN_SECONDS );
 			}
 			$woo = isset( $snapshot['woo'] ) ? $snapshot['woo'] : null;
 

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -388,7 +388,7 @@ class ProPerf_Admin_Settings {
 		if ( '' === $value || null === $value ) {
 			return '';
 		}
-		$unit = isset( $_POST['properf_order_itemmeta_db_alert_threshold_unit'] )
+		$unit = ( ! empty( $_POST ) && isset( $_POST['properf_order_itemmeta_db_alert_threshold_unit'] ) )
 			? sanitize_key( wp_unslash( $_POST['properf_order_itemmeta_db_alert_threshold_unit'] ) )
 			: 'mb';
 		if ( ! in_array( $unit, array( 'mb', 'gb' ), true ) ) {

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -31,6 +31,7 @@ class ProPerf_Admin_Settings {
 		add_action( 'update_option_properf_order_itemmeta_db_alert_threshold', array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
 		add_action( 'add_option_properf_order_itemmeta_db_alert_threshold', array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
 		add_action( 'delete_option_properf_order_itemmeta_db_alert_threshold', array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
+		add_action( 'activate_' . plugin_basename( PROPERF_DIR . 'properf-wordpress-adapter.php' ), array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
 	}
 
 	/**

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -32,7 +32,9 @@ class ProPerf_Admin_Settings {
 		add_action( 'add_option_properf_order_itemmeta_db_alert_threshold', array( 'ProPerf_Data_Collector', 'bust_woo_metrics_cache' ) );
 		add_action( 'delete_option_properf_order_itemmeta_db_alert_threshold', array( 'ProPerf_Data_Collector', 'bust_woo_metrics_cache' ) );
 		add_action( 'activated_plugin',   array( 'ProPerf_Data_Collector', 'bust_server_metrics_cache' ) );
+		add_action( 'activated_plugin',   array( 'ProPerf_Data_Collector', 'bust_autoload_metrics_cache' ) );
 		add_action( 'deactivated_plugin', array( 'ProPerf_Data_Collector', 'bust_server_metrics_cache' ) );
+		add_action( 'deactivated_plugin', array( 'ProPerf_Data_Collector', 'bust_autoload_metrics_cache' ) );
 	}
 
 	/**

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -24,13 +24,13 @@ class ProPerf_Admin_Settings {
 	 */
 	public static function register_persistent_hooks() {
 		add_action( 'update_option_properf_last_archival_date', array( __CLASS__, 'reset_qet_on_archival_change' ), 10, 2 );
-		add_action( 'update_option_properf_last_archival_date', array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
-		add_action( 'add_option_properf_last_archival_date', array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
-		add_action( 'update_option_properf_archival_threshold_years', array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
-		add_action( 'add_option_properf_archival_threshold_years', array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
-		add_action( 'update_option_properf_order_itemmeta_db_alert_threshold', array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
-		add_action( 'add_option_properf_order_itemmeta_db_alert_threshold', array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
-		add_action( 'delete_option_properf_order_itemmeta_db_alert_threshold', array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
+		add_action( 'update_option_properf_last_archival_date', array( 'ProPerf_Data_Collector', 'bust_woo_metrics_cache' ) );
+		add_action( 'add_option_properf_last_archival_date', array( 'ProPerf_Data_Collector', 'bust_woo_metrics_cache' ) );
+		add_action( 'update_option_properf_archival_threshold_years', array( 'ProPerf_Data_Collector', 'bust_woo_metrics_cache' ) );
+		add_action( 'add_option_properf_archival_threshold_years', array( 'ProPerf_Data_Collector', 'bust_woo_metrics_cache' ) );
+		add_action( 'update_option_properf_order_itemmeta_db_alert_threshold', array( 'ProPerf_Data_Collector', 'bust_woo_metrics_cache' ) );
+		add_action( 'add_option_properf_order_itemmeta_db_alert_threshold', array( 'ProPerf_Data_Collector', 'bust_woo_metrics_cache' ) );
+		add_action( 'delete_option_properf_order_itemmeta_db_alert_threshold', array( 'ProPerf_Data_Collector', 'bust_woo_metrics_cache' ) );
 		add_action( 'activate_' . plugin_basename( PROPERF_DIR . 'properf-wordpress-adapter.php' ), array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
 	}
 
@@ -40,8 +40,8 @@ class ProPerf_Admin_Settings {
 	public static function init() {
 		add_action( 'admin_init', array( __CLASS__, 'register_settings' ), 20 );
 		add_filter( 'wp_redirect', array( __CLASS__, 'settings_redirect' ) );
-		add_action( 'activated_plugin',   array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
-		add_action( 'deactivated_plugin', array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
+		add_action( 'activated_plugin',   array( 'ProPerf_Data_Collector', 'bust_server_metrics_cache' ) );
+		add_action( 'deactivated_plugin', array( 'ProPerf_Data_Collector', 'bust_server_metrics_cache' ) );
 	}
 
 	/**

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -31,7 +31,8 @@ class ProPerf_Admin_Settings {
 		add_action( 'update_option_properf_order_itemmeta_db_alert_threshold', array( 'ProPerf_Data_Collector', 'bust_woo_metrics_cache' ) );
 		add_action( 'add_option_properf_order_itemmeta_db_alert_threshold', array( 'ProPerf_Data_Collector', 'bust_woo_metrics_cache' ) );
 		add_action( 'delete_option_properf_order_itemmeta_db_alert_threshold', array( 'ProPerf_Data_Collector', 'bust_woo_metrics_cache' ) );
-		add_action( 'activate_' . plugin_basename( PROPERF_DIR . 'properf-wordpress-adapter.php' ), array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
+		add_action( 'activated_plugin',   array( 'ProPerf_Data_Collector', 'bust_server_metrics_cache' ) );
+		add_action( 'deactivated_plugin', array( 'ProPerf_Data_Collector', 'bust_server_metrics_cache' ) );
 	}
 
 	/**
@@ -40,8 +41,6 @@ class ProPerf_Admin_Settings {
 	public static function init() {
 		add_action( 'admin_init', array( __CLASS__, 'register_settings' ), 20 );
 		add_filter( 'wp_redirect', array( __CLASS__, 'settings_redirect' ) );
-		add_action( 'activated_plugin',   array( 'ProPerf_Data_Collector', 'bust_server_metrics_cache' ) );
-		add_action( 'deactivated_plugin', array( 'ProPerf_Data_Collector', 'bust_server_metrics_cache' ) );
 	}
 
 	/**

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -40,6 +40,8 @@ class ProPerf_Admin_Settings {
 	public static function init() {
 		add_action( 'admin_init', array( __CLASS__, 'register_settings' ), 20 );
 		add_filter( 'wp_redirect', array( __CLASS__, 'settings_redirect' ) );
+		add_action( 'activated_plugin',   array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
+		add_action( 'deactivated_plugin', array( 'ProPerf_Data_Collector', 'bust_metrics_cache' ) );
 	}
 
 	/**

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -473,7 +473,11 @@ class ProPerf_Admin_Settings {
 					$suggestion_notice = __( 'Could not estimate a valid threshold from current data — set manually.', 'properf' );
 				}
 			} elseif ( $woo && ( empty( $woo['orders_older_than_threshold'] ) || 0 === (int) $woo['orders_older_than_threshold'] ) ) {
-				$suggestion_notice = __( 'No archivable orders found for the current retention window — set threshold manually or leave empty to disable.', 'properf' );
+				if ( empty( $woo['total_orders'] ) || 0 === (int) $woo['total_orders'] ) {
+					$suggestion_notice = __( 'No orders yet — leave empty to disable the alert.', 'properf' );
+				} else {
+					$suggestion_notice = __( 'No archivable orders found for the current retention window — set threshold manually or leave empty to disable.', 'properf' );
+				}
 			}
 		}
 		?>

--- a/includes/class-bigquery-client.php
+++ b/includes/class-bigquery-client.php
@@ -146,6 +146,11 @@ class ProPerf_BigQuery_Client {
 					array( 'name' => 'woo_baseline_qet_ms',             'type' => 'INTEGER', 'mode' => 'NULLABLE' ),
 					array( 'name' => 'woo_archival_signal_active',      'type' => 'BOOLEAN', 'mode' => 'NULLABLE' ),
 					array( 'name' => 'woo_alert_threshold_mb',          'type' => 'INTEGER', 'mode' => 'NULLABLE' ),
+					array( 'name' => 'active_plugin_count',             'type' => 'INTEGER', 'mode' => 'NULLABLE' ),
+					array( 'name' => 'inactive_plugin_count',           'type' => 'INTEGER', 'mode' => 'NULLABLE' ),
+					array( 'name' => 'hook_count',                      'type' => 'INTEGER', 'mode' => 'NULLABLE' ),
+					array( 'name' => 'total_db_size_mb',                'type' => 'FLOAT',   'mode' => 'NULLABLE' ),
+					array( 'name' => 'db_table_sizes_json',             'type' => 'STRING',  'mode' => 'NULLABLE' ),
 				),
 			);
 

--- a/includes/class-bigquery-client.php
+++ b/includes/class-bigquery-client.php
@@ -150,15 +150,6 @@ class ProPerf_BigQuery_Client {
 					array( 'name' => 'inactive_plugin_count',           'type' => 'INTEGER', 'mode' => 'NULLABLE' ),
 					array( 'name' => 'hook_count',                      'type' => 'INTEGER', 'mode' => 'NULLABLE' ),
 					array( 'name' => 'total_db_size_mb',                'type' => 'FLOAT',   'mode' => 'NULLABLE' ),
-					array(
-						'name'   => 'db_table_sizes',
-						'type'   => 'RECORD',
-						'mode'   => 'REPEATED',
-						'fields' => array(
-							array( 'name' => 'name',    'type' => 'STRING' ),
-							array( 'name' => 'size_mb', 'type' => 'FLOAT'  ),
-						),
-					),
 				),
 			);
 

--- a/includes/class-bigquery-client.php
+++ b/includes/class-bigquery-client.php
@@ -150,7 +150,15 @@ class ProPerf_BigQuery_Client {
 					array( 'name' => 'inactive_plugin_count',           'type' => 'INTEGER', 'mode' => 'NULLABLE' ),
 					array( 'name' => 'hook_count',                      'type' => 'INTEGER', 'mode' => 'NULLABLE' ),
 					array( 'name' => 'total_db_size_mb',                'type' => 'FLOAT',   'mode' => 'NULLABLE' ),
-					array( 'name' => 'db_table_sizes_json',             'type' => 'STRING',  'mode' => 'NULLABLE' ),
+					array(
+						'name'   => 'db_table_sizes',
+						'type'   => 'RECORD',
+						'mode'   => 'REPEATED',
+						'fields' => array(
+							array( 'name' => 'name',    'type' => 'STRING' ),
+							array( 'name' => 'size_mb', 'type' => 'FLOAT'  ),
+						),
+					),
 				),
 			);
 

--- a/includes/class-bigquery-client.php
+++ b/includes/class-bigquery-client.php
@@ -184,7 +184,6 @@ class ProPerf_BigQuery_Client {
 				return false;
 			}
 
-			update_option( 'properf_bq_last_sync', time() );
 			return true;
 		} catch ( GoogleException $e ) {
 			$this->last_error = 'Google SDK Error: ' . $e->getMessage();

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -271,6 +271,10 @@ class ProPerf_Data_Collector {
 		$active_count   = count( $active_keys );
 		$inactive_count = count( $all_plugins ) - $active_count;
 
+		// Counts callbacks registered in $wp_filter at the moment this method runs
+		// (typically cron context or admin dashboard). Not "hooks per frontend
+		// page" — frontend-only hooks registered later in the request lifecycle
+		// aren't counted. Meant as a directional signal for plugin-stack heaviness.
 		global $wp_filter;
 		$hook_count = 0;
 		foreach ( $wp_filter as $hook ) {
@@ -412,6 +416,7 @@ class ProPerf_Data_Collector {
 
 		delete_transient( self::WOO_METRICS_CACHE_KEY );
 		delete_transient( self::SERVER_METRICS_CACHE_KEY );
+		delete_transient( self::AUTOLOAD_METRICS_CACHE_KEY );
 
 		try {
 			$metrics = $this->get_data();
@@ -506,6 +511,9 @@ class ProPerf_Data_Collector {
 
 	public static function bust_woo_metrics_cache() {
 		delete_transient( self::WOO_METRICS_CACHE_KEY );
+	}
+
+	public static function bust_autoload_metrics_cache() {
 		delete_transient( self::AUTOLOAD_METRICS_CACHE_KEY );
 	}
 
@@ -515,6 +523,7 @@ class ProPerf_Data_Collector {
 
 	public static function bust_metrics_cache() {
 		self::bust_woo_metrics_cache();
+		self::bust_autoload_metrics_cache();
 		self::bust_server_metrics_cache();
 	}
 

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -493,12 +493,14 @@ class ProPerf_Data_Collector {
 	 * @return array Formatted data for BigQuery.
 	 */
 	public function format_for_bigquery( $metrics ) {
-		$site_url         = get_site_url();
-		$timestamp        = gmdate( 'Y-m-d H:i:s' );
-		$table_sizes_json = wp_json_encode( $metrics['server']['db_table_sizes'] );
-		if ( false === $table_sizes_json ) {
-			error_log( 'ProPerf Error: Failed to JSON-encode db_table_sizes for ' . $site_url . ' — possible non-UTF-8 table name. Sending empty object to BigQuery.' );
-			$table_sizes_json = '{}';
+		$site_url    = get_site_url();
+		$timestamp   = gmdate( 'Y-m-d H:i:s' );
+		$table_sizes = array();
+		foreach ( $metrics['server']['db_table_sizes'] as $name => $size_mb ) {
+			$table_sizes[] = array(
+				'name'    => $name,
+				'size_mb' => $size_mb,
+			);
 		}
 
 		return array(
@@ -521,7 +523,7 @@ class ProPerf_Data_Collector {
 			'inactive_plugin_count'           => $metrics['server']['inactive_plugin_count'],
 			'hook_count'                      => $metrics['server']['hook_count'],
 			'total_db_size_mb'                => $metrics['server']['total_db_size_mb'],
-			'db_table_sizes_json'             => $table_sizes_json,
+			'db_table_sizes'                  => $table_sizes,
 		);
 	}
 }

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -252,10 +252,10 @@ class ProPerf_Data_Collector {
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
-		validate_active_plugins();
 		$all_plugins    = get_plugins();
 		$active_plugins = get_option( 'active_plugins', array() );
-		$active_count   = count( $active_plugins );
+		$active_keys    = array_intersect( $active_plugins, array_keys( $all_plugins ) );
+		$active_count   = count( $active_keys );
 		$inactive_count = count( $all_plugins ) - $active_count;
 
 		global $wp_filter;

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -14,8 +14,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class ProPerf_Data_Collector {
 
-	const WOO_METRICS_CACHE_KEY    = 'properf_woo_metrics_snapshot';
-	const SERVER_METRICS_CACHE_KEY = 'properf_server_metrics_snapshot';
+	const WOO_METRICS_CACHE_KEY       = 'properf_woo_metrics_snapshot';
+	const SERVER_METRICS_CACHE_KEY    = 'properf_server_metrics_snapshot';
+	const AUTOLOAD_METRICS_CACHE_KEY  = 'properf_autoload_metrics_snapshot';
 
 	/**
 	 * Get collected data.
@@ -36,6 +37,11 @@ class ProPerf_Data_Collector {
 	 * @return array Autoloaded options data.
 	 */
 	public function collect_autoloaded_options() {
+		$cached = get_transient( self::AUTOLOAD_METRICS_CACHE_KEY );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
 		global $wpdb;
 		$autoload_clause = "autoload IN ('yes', 'on', 'auto', 'auto-on')";
 
@@ -65,7 +71,7 @@ class ProPerf_Data_Collector {
 			}
 		}
 
-		return array(
+		$result = array(
 			'autoloaded_option' => array(
 				'count'         => $autoloaded_option_count,
 				'size_bytes'    => $autoloaded_option_size_bytes,
@@ -73,6 +79,8 @@ class ProPerf_Data_Collector {
 				'error'         => null,
 			),
 		);
+		set_transient( self::AUTOLOAD_METRICS_CACHE_KEY, $result, HOUR_IN_SECONDS );
+		return $result;
 	}
 
 	/**
@@ -505,6 +513,7 @@ class ProPerf_Data_Collector {
 	public static function bust_metrics_cache() {
 		delete_transient( self::WOO_METRICS_CACHE_KEY );
 		delete_transient( self::SERVER_METRICS_CACHE_KEY );
+		delete_transient( self::AUTOLOAD_METRICS_CACHE_KEY );
 	}
 
 	/**

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -506,14 +506,18 @@ class ProPerf_Data_Collector {
 		);
 	}
 
-	/**
-	 * Delete the cached WooCommerce metrics snapshot.
-	 * Called by settings hooks when archival date or threshold changes.
-	 */
-	public static function bust_metrics_cache() {
+	public static function bust_woo_metrics_cache() {
 		delete_transient( self::WOO_METRICS_CACHE_KEY );
-		delete_transient( self::SERVER_METRICS_CACHE_KEY );
 		delete_transient( self::AUTOLOAD_METRICS_CACHE_KEY );
+	}
+
+	public static function bust_server_metrics_cache() {
+		delete_transient( self::SERVER_METRICS_CACHE_KEY );
+	}
+
+	public static function bust_metrics_cache() {
+		self::bust_woo_metrics_cache();
+		self::bust_server_metrics_cache();
 	}
 
 	/**

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -246,6 +246,11 @@ class ProPerf_Data_Collector {
 	public function collect_server_metrics() {
 		$cached = get_transient( self::SERVER_METRICS_CACHE_KEY );
 		if ( false !== $cached ) {
+			if ( ! empty( $cached['_had_invalid_names'] ) ) {
+				update_option( 'properf_table_name_encoding_warning', $cached['_had_invalid_names'] );
+			} else {
+				delete_option( 'properf_table_name_encoding_warning' );
+			}
 			return $cached;
 		}
 
@@ -303,8 +308,10 @@ class ProPerf_Data_Collector {
 			delete_option( 'properf_table_name_encoding_warning' );
 		}
 
-		$result = array(
-			'server' => array(
+		$warning_timestamp = $had_invalid_names ? gmdate( 'Y-m-d H:i:s' ) : '';
+		$result            = array(
+			'_had_invalid_names' => $warning_timestamp,
+			'server'             => array(
 				'active_plugin_count'   => $active_count,
 				'inactive_plugin_count' => $inactive_count,
 				'hook_count'            => $hook_count,
@@ -312,6 +319,11 @@ class ProPerf_Data_Collector {
 				'total_db_size_mb'      => round( $total_db_size_mb, 4 ),
 			),
 		);
+		if ( $had_invalid_names ) {
+			update_option( 'properf_table_name_encoding_warning', $warning_timestamp );
+		} else {
+			delete_option( 'properf_table_name_encoding_warning' );
+		}
 		set_transient( self::SERVER_METRICS_CACHE_KEY, $result, HOUR_IN_SECONDS );
 		return $result;
 	}

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -16,6 +16,7 @@ class ProPerf_Data_Collector {
 
 	const WOO_METRICS_CACHE_KEY       = 'properf_woo_metrics_snapshot';
 	const SERVER_METRICS_CACHE_KEY    = 'properf_server_metrics_snapshot';
+	const PLUGIN_METRICS_CACHE_KEY    = 'properf_plugin_metrics_snapshot';
 	const AUTOLOAD_METRICS_CACHE_KEY  = 'properf_autoload_metrics_snapshot';
 
 	/**
@@ -247,18 +248,15 @@ class ProPerf_Data_Collector {
 	}
 
 	/**
-	 * Collect server-level metrics: plugin counts, hook callback count, and DB table sizes.
+	 * Collect active/inactive plugin count and hook callback count.
+	 * Cached separately from table sizes: this data changes on plugin (de)activation,
+	 * not on general DB writes, so it has its own invalidation triggers and TTL.
 	 *
-	 * @return array Server metrics keyed under 'server'.
+	 * @return array {active_plugin_count, inactive_plugin_count, hook_count}
 	 */
-	public function collect_server_metrics() {
-		$cached = get_transient( self::SERVER_METRICS_CACHE_KEY );
+	private function collect_plugin_stats() {
+		$cached = get_transient( self::PLUGIN_METRICS_CACHE_KEY );
 		if ( false !== $cached ) {
-			if ( ! empty( $cached['_had_invalid_names'] ) ) {
-				update_option( 'properf_table_name_encoding_warning', $cached['_had_invalid_names'] );
-			} elseif ( get_option( 'properf_table_name_encoding_warning' ) ) {
-				delete_option( 'properf_table_name_encoding_warning' );
-			}
 			return $cached;
 		}
 
@@ -267,6 +265,16 @@ class ProPerf_Data_Collector {
 		}
 		$all_plugins    = get_plugins();
 		$active_plugins = get_option( 'active_plugins', array() );
+		if ( is_multisite() ) {
+			// Network-activated plugins live in a site option, not this site's
+			// active_plugins — without this they're miscounted as inactive.
+			$active_plugins = array_unique(
+				array_merge(
+					$active_plugins,
+					array_keys( get_site_option( 'active_sitewide_plugins', array() ) )
+				)
+			);
+		}
 		$active_keys    = array_intersect( $active_plugins, array_keys( $all_plugins ) );
 		$active_count   = count( $active_keys );
 		$inactive_count = count( $all_plugins ) - $active_count;
@@ -284,6 +292,28 @@ class ProPerf_Data_Collector {
 			foreach ( $hook->callbacks as $priority_callbacks ) {
 				$hook_count += count( $priority_callbacks );
 			}
+		}
+
+		$result = array(
+			'active_plugin_count'   => $active_count,
+			'inactive_plugin_count' => $inactive_count,
+			'hook_count'            => $hook_count,
+		);
+		set_transient( self::PLUGIN_METRICS_CACHE_KEY, $result, HOUR_IN_SECONDS );
+		return $result;
+	}
+
+	/**
+	 * Collect per-table DB sizes, the total DB size, and any table-name encoding warning.
+	 * Cached separately from plugin stats: this data changes on general DB writes,
+	 * not plugin (de)activation, so it isn't busted by plugin-toggle hooks.
+	 *
+	 * @return array {db_table_sizes, total_db_size_mb, table_name_warning}
+	 */
+	private function collect_table_stats() {
+		$cached = get_transient( self::SERVER_METRICS_CACHE_KEY );
+		if ( false !== $cached ) {
+			return $cached;
 		}
 
 		global $wpdb;
@@ -305,36 +335,49 @@ class ProPerf_Data_Collector {
 		if ( $tables ) {
 			foreach ( $tables as $table ) {
 				$raw_name = $table->table_name;
-				$clean    = iconv( 'UTF-8', 'UTF-8//IGNORE', $raw_name );
+				$clean    = function_exists( 'iconv' ) ? iconv( 'UTF-8', 'UTF-8//IGNORE', $raw_name ) : $raw_name;
+				$size_mb  = floatval( $table->size_mb );
+				// Always count toward the total, even if the name can't be
+				// displayed cleanly — an unreadable name shouldn't shrink the
+				// reported DB size.
+				$total_db_size_mb += $size_mb;
+
 				if ( $clean !== $raw_name ) {
 					$had_invalid_names = true;
 					if ( false === $clean || '' === $clean ) {
 						continue;
 					}
 				}
-				$size_mb                      = floatval( $table->size_mb );
-				$db_table_sizes[ $clean ]     = $size_mb;
-				$total_db_size_mb            += $size_mb;
+
+				// Two distinct corrupted names can sanitize to the same string;
+				// accumulate rather than overwrite so the total always matches
+				// the sum of the displayed rows.
+				if ( isset( $db_table_sizes[ $clean ] ) ) {
+					$db_table_sizes[ $clean ] += $size_mb;
+				} else {
+					$db_table_sizes[ $clean ] = $size_mb;
+				}
 			}
 		}
-		$warning_timestamp = $had_invalid_names ? gmdate( 'Y-m-d H:i:s' ) : '';
-		$result            = array(
-			'_had_invalid_names' => $warning_timestamp,
-			'server'             => array(
-				'active_plugin_count'   => $active_count,
-				'inactive_plugin_count' => $inactive_count,
-				'hook_count'            => $hook_count,
-				'db_table_sizes'        => $db_table_sizes,
-				'total_db_size_mb'      => round( $total_db_size_mb, 4 ),
-			),
+
+		$result = array(
+			'db_table_sizes'     => $db_table_sizes,
+			'total_db_size_mb'   => round( $total_db_size_mb, 4 ),
+			'table_name_warning' => $had_invalid_names ? gmdate( 'Y-m-d H:i:s' ) : '',
 		);
-		if ( $had_invalid_names ) {
-			update_option( 'properf_table_name_encoding_warning', $warning_timestamp );
-		} elseif ( get_option( 'properf_table_name_encoding_warning' ) ) {
-			delete_option( 'properf_table_name_encoding_warning' );
-		}
 		set_transient( self::SERVER_METRICS_CACHE_KEY, $result, HOUR_IN_SECONDS );
 		return $result;
+	}
+
+	/**
+	 * Collect server-level metrics: plugin counts, hook callback count, and DB table sizes.
+	 *
+	 * @return array Server metrics keyed under 'server'.
+	 */
+	public function collect_server_metrics() {
+		return array(
+			'server' => array_merge( $this->collect_plugin_stats(), $this->collect_table_stats() ),
+		);
 	}
 
 	/**
@@ -414,9 +457,7 @@ class ProPerf_Data_Collector {
 	public function collect_and_push() {
 		require_once PROPERF_DIR . 'includes/class-bigquery-client.php';
 
-		delete_transient( self::WOO_METRICS_CACHE_KEY );
-		delete_transient( self::SERVER_METRICS_CACHE_KEY );
-		delete_transient( self::AUTOLOAD_METRICS_CACHE_KEY );
+		self::bust_metrics_cache();
 
 		try {
 			$metrics = $this->get_data();
@@ -517,6 +558,10 @@ class ProPerf_Data_Collector {
 		delete_transient( self::AUTOLOAD_METRICS_CACHE_KEY );
 	}
 
+	public static function bust_plugin_metrics_cache() {
+		delete_transient( self::PLUGIN_METRICS_CACHE_KEY );
+	}
+
 	public static function bust_server_metrics_cache() {
 		delete_transient( self::SERVER_METRICS_CACHE_KEY );
 	}
@@ -524,6 +569,7 @@ class ProPerf_Data_Collector {
 	public static function bust_metrics_cache() {
 		self::bust_woo_metrics_cache();
 		self::bust_autoload_metrics_cache();
+		self::bust_plugin_metrics_cache();
 		self::bust_server_metrics_cache();
 	}
 

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -310,12 +310,6 @@ class ProPerf_Data_Collector {
 				$total_db_size_mb            += $size_mb;
 			}
 		}
-		if ( $had_invalid_names ) {
-			update_option( 'properf_table_name_encoding_warning', gmdate( 'Y-m-d H:i:s' ) );
-		} else {
-			delete_option( 'properf_table_name_encoding_warning' );
-		}
-
 		$warning_timestamp = $had_invalid_names ? gmdate( 'Y-m-d H:i:s' ) : '';
 		$result            = array(
 			'_had_invalid_names' => $warning_timestamp,
@@ -329,7 +323,7 @@ class ProPerf_Data_Collector {
 		);
 		if ( $had_invalid_names ) {
 			update_option( 'properf_table_name_encoding_warning', $warning_timestamp );
-		} else {
+		} elseif ( get_option( 'properf_table_name_encoding_warning' ) ) {
 			delete_option( 'properf_table_name_encoding_warning' );
 		}
 		set_transient( self::SERVER_METRICS_CACHE_KEY, $result, HOUR_IN_SECONDS );

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -14,7 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class ProPerf_Data_Collector {
 
-	const WOO_METRICS_CACHE_KEY = 'properf_woo_metrics_snapshot';
+	const WOO_METRICS_CACHE_KEY    = 'properf_woo_metrics_snapshot';
+	const SERVER_METRICS_CACHE_KEY = 'properf_server_metrics_snapshot';
 
 	/**
 	 * Get collected data.
@@ -243,6 +244,11 @@ class ProPerf_Data_Collector {
 	 * @return array Server metrics keyed under 'server'.
 	 */
 	public function collect_server_metrics() {
+		$cached = get_transient( self::SERVER_METRICS_CACHE_KEY );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
@@ -297,7 +303,7 @@ class ProPerf_Data_Collector {
 			delete_option( 'properf_table_name_encoding_warning' );
 		}
 
-		return array(
+		$result = array(
 			'server' => array(
 				'active_plugin_count'   => $active_count,
 				'inactive_plugin_count' => $inactive_count,
@@ -306,6 +312,8 @@ class ProPerf_Data_Collector {
 				'total_db_size_mb'      => round( $total_db_size_mb, 4 ),
 			),
 		);
+		set_transient( self::SERVER_METRICS_CACHE_KEY, $result, HOUR_IN_SECONDS );
+		return $result;
 	}
 
 	/**
@@ -484,6 +492,7 @@ class ProPerf_Data_Collector {
 	 */
 	public static function bust_metrics_cache() {
 		delete_transient( self::WOO_METRICS_CACHE_KEY );
+		delete_transient( self::SERVER_METRICS_CACHE_KEY );
 	}
 
 	/**

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -273,14 +273,28 @@ class ProPerf_Data_Collector {
 			)
 		);
 
-		$db_table_sizes   = array();
-		$total_db_size_mb = 0.0;
+		$db_table_sizes    = array();
+		$total_db_size_mb  = 0.0;
+		$had_invalid_names = false;
 		if ( $tables ) {
 			foreach ( $tables as $table ) {
-				$size_mb                                 = floatval( $table->size_mb );
-				$db_table_sizes[ $table->table_name ] = $size_mb;
-				$total_db_size_mb                       += $size_mb;
+				$raw_name = $table->table_name;
+				$clean    = iconv( 'UTF-8', 'UTF-8//IGNORE', $raw_name );
+				if ( $clean !== $raw_name ) {
+					$had_invalid_names = true;
+					if ( '' === $clean ) {
+						continue;
+					}
+				}
+				$size_mb                      = floatval( $table->size_mb );
+				$db_table_sizes[ $clean ]     = $size_mb;
+				$total_db_size_mb            += $size_mb;
 			}
+		}
+		if ( $had_invalid_names ) {
+			update_option( 'properf_table_name_encoding_warning', gmdate( 'Y-m-d H:i:s' ) );
+		} else {
+			delete_option( 'properf_table_name_encoding_warning' );
 		}
 
 		return array(

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -256,7 +256,7 @@ class ProPerf_Data_Collector {
 		if ( false !== $cached ) {
 			if ( ! empty( $cached['_had_invalid_names'] ) ) {
 				update_option( 'properf_table_name_encoding_warning', $cached['_had_invalid_names'] );
-			} else {
+			} elseif ( get_option( 'properf_table_name_encoding_warning' ) ) {
 				delete_option( 'properf_table_name_encoding_warning' );
 			}
 			return $cached;
@@ -274,6 +274,9 @@ class ProPerf_Data_Collector {
 		global $wp_filter;
 		$hook_count = 0;
 		foreach ( $wp_filter as $hook ) {
+			if ( ! ( $hook instanceof WP_Hook ) ) {
+				continue;
+			}
 			foreach ( $hook->callbacks as $priority_callbacks ) {
 				$hook_count += count( $priority_callbacks );
 			}
@@ -408,6 +411,7 @@ class ProPerf_Data_Collector {
 		require_once PROPERF_DIR . 'includes/class-bigquery-client.php';
 
 		delete_transient( self::WOO_METRICS_CACHE_KEY );
+		delete_transient( self::SERVER_METRICS_CACHE_KEY );
 
 		try {
 			$metrics = $this->get_data();

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -246,6 +246,7 @@ class ProPerf_Data_Collector {
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
+		validate_active_plugins();
 		$all_plugins    = get_plugins();
 		$active_plugins = get_option( 'active_plugins', array() );
 		$active_count   = count( $active_plugins );

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -24,7 +24,8 @@ class ProPerf_Data_Collector {
 	public function get_data() {
 		return array_merge(
 			$this->collect_autoloaded_options(),
-			$this->collect_woo_order_metrics()
+			$this->collect_woo_order_metrics(),
+			$this->collect_server_metrics()
 		);
 	}
 
@@ -237,6 +238,62 @@ class ProPerf_Data_Collector {
 	}
 
 	/**
+	 * Collect server-level metrics: plugin counts, hook callback count, and DB table sizes.
+	 *
+	 * @return array Server metrics keyed under 'server'.
+	 */
+	public function collect_server_metrics() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		$all_plugins    = get_plugins();
+		$active_plugins = get_option( 'active_plugins', array() );
+		$active_count   = count( $active_plugins );
+		$inactive_count = count( $all_plugins ) - $active_count;
+
+		global $wp_filter;
+		$hook_count = 0;
+		foreach ( $wp_filter as $hook ) {
+			foreach ( $hook->callbacks as $priority_callbacks ) {
+				$hook_count += count( $priority_callbacks );
+			}
+		}
+
+		global $wpdb;
+		$db_name = DB_NAME;
+		$tables  = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT TABLE_NAME as table_name,
+					ROUND((DATA_LENGTH + INDEX_LENGTH) / 1024 / 1024, 4) as size_mb
+				FROM information_schema.TABLES
+				WHERE TABLE_SCHEMA = %s
+				ORDER BY (DATA_LENGTH + INDEX_LENGTH) DESC',
+				$db_name
+			)
+		);
+
+		$db_table_sizes   = array();
+		$total_db_size_mb = 0.0;
+		if ( $tables ) {
+			foreach ( $tables as $table ) {
+				$size_mb                                 = floatval( $table->size_mb );
+				$db_table_sizes[ $table->table_name ] = $size_mb;
+				$total_db_size_mb                       += $size_mb;
+			}
+		}
+
+		return array(
+			'server' => array(
+				'active_plugin_count'   => $active_count,
+				'inactive_plugin_count' => $inactive_count,
+				'hook_count'            => $hook_count,
+				'db_table_sizes'        => $db_table_sizes,
+				'total_db_size_mb'      => round( $total_db_size_mb, 4 ),
+			),
+		);
+	}
+
+	/**
 	 * Record a QET reading for baseline computation. Call after each successful push.
 	 * Multiple same-day pushes are averaged into a single daily entry.
 	 *
@@ -440,6 +497,11 @@ class ProPerf_Data_Collector {
 			'woo_baseline_qet_ms'             => $metrics['woo']['baseline_qet_ms'],
 			'woo_archival_signal_active'      => $metrics['woo']['archival_signal_active'],
 			'woo_alert_threshold_mb'          => $metrics['woo']['alert_threshold_mb'],
+			'active_plugin_count'             => $metrics['server']['active_plugin_count'],
+			'inactive_plugin_count'           => $metrics['server']['inactive_plugin_count'],
+			'hook_count'                      => $metrics['server']['hook_count'],
+			'total_db_size_mb'                => $metrics['server']['total_db_size_mb'],
+			'db_table_sizes_json'             => wp_json_encode( $metrics['server']['db_table_sizes'] ),
 		);
 	}
 }

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -479,8 +479,13 @@ class ProPerf_Data_Collector {
 	 * @return array Formatted data for BigQuery.
 	 */
 	public function format_for_bigquery( $metrics ) {
-		$site_url  = get_site_url();
-		$timestamp = gmdate( 'Y-m-d H:i:s' );
+		$site_url         = get_site_url();
+		$timestamp        = gmdate( 'Y-m-d H:i:s' );
+		$table_sizes_json = wp_json_encode( $metrics['server']['db_table_sizes'] );
+		if ( false === $table_sizes_json ) {
+			error_log( 'ProPerf Error: Failed to JSON-encode db_table_sizes for ' . $site_url . ' — possible non-UTF-8 table name. Sending empty object to BigQuery.' );
+			$table_sizes_json = '{}';
+		}
 
 		return array(
 			'timestamp_utc'                   => $timestamp,
@@ -502,7 +507,7 @@ class ProPerf_Data_Collector {
 			'inactive_plugin_count'           => $metrics['server']['inactive_plugin_count'],
 			'hook_count'                      => $metrics['server']['hook_count'],
 			'total_db_size_mb'                => $metrics['server']['total_db_size_mb'],
-			'db_table_sizes_json'             => wp_json_encode( $metrics['server']['db_table_sizes'] ),
+			'db_table_sizes_json'             => $table_sizes_json,
 		);
 	}
 }

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -288,7 +288,7 @@ class ProPerf_Data_Collector {
 				$clean    = iconv( 'UTF-8', 'UTF-8//IGNORE', $raw_name );
 				if ( $clean !== $raw_name ) {
 					$had_invalid_names = true;
-					if ( '' === $clean ) {
+					if ( false === $clean || '' === $clean ) {
 						continue;
 					}
 				}

--- a/includes/class-data-collector.php
+++ b/includes/class-data-collector.php
@@ -525,15 +525,8 @@ class ProPerf_Data_Collector {
 	 * @return array Formatted data for BigQuery.
 	 */
 	public function format_for_bigquery( $metrics ) {
-		$site_url    = get_site_url();
-		$timestamp   = gmdate( 'Y-m-d H:i:s' );
-		$table_sizes = array();
-		foreach ( $metrics['server']['db_table_sizes'] as $name => $size_mb ) {
-			$table_sizes[] = array(
-				'name'    => $name,
-				'size_mb' => $size_mb,
-			);
-		}
+		$site_url  = get_site_url();
+		$timestamp = gmdate( 'Y-m-d H:i:s' );
 
 		return array(
 			'timestamp_utc'                   => $timestamp,
@@ -555,7 +548,6 @@ class ProPerf_Data_Collector {
 			'inactive_plugin_count'           => $metrics['server']['inactive_plugin_count'],
 			'hook_count'                      => $metrics['server']['hook_count'],
 			'total_db_size_mb'                => $metrics['server']['total_db_size_mb'],
-			'db_table_sizes'                  => $table_sizes,
 		);
 	}
 }

--- a/includes/class-live-data.php
+++ b/includes/class-live-data.php
@@ -33,6 +33,7 @@ class ProPerf_Live_Data {
 				'hook_count'            => 0,
 				'db_table_sizes'        => array(),
 				'total_db_size_mb'      => 0.0,
+				'table_name_warning'    => '',
 			),
 			'woo'               => array(
 				'order_items_size_mb'         => 0.0,

--- a/includes/class-live-data.php
+++ b/includes/class-live-data.php
@@ -27,6 +27,13 @@ class ProPerf_Live_Data {
 				'top_size_keys' => array(),
 				'error'         => null,
 			),
+			'server'            => array(
+				'active_plugin_count'   => 0,
+				'inactive_plugin_count' => 0,
+				'hook_count'            => 0,
+				'db_table_sizes'        => array(),
+				'total_db_size_mb'      => 0.0,
+			),
 			'woo'               => array(
 				'order_items_size_mb'         => 0.0,
 				'order_itemmeta_size_mb'      => 0.0,

--- a/properf-wordpress-adapter.php
+++ b/properf-wordpress-adapter.php
@@ -28,6 +28,7 @@ require_once PROPERF_DIR . 'includes/class-admin-dashboard.php';
  */
 function properf_activate_plugin() {
 	properf_schedule_metrics_collection();
+	ProPerf_Data_Collector::bust_metrics_cache();
 }
 register_activation_hook( __FILE__, 'properf_activate_plugin' );
 

--- a/properf-wordpress-adapter.php
+++ b/properf-wordpress-adapter.php
@@ -3,7 +3,7 @@
  * Plugin Name: ProPerf WordPress Adapter
  * Plugin URI: https://coloredcow.com
  * Description: Collects and displays database health metrics (autoloaded options)
- * Version: 1.1.0
+ * Version: 1.1.1
  * Author: ColoredCow
  * License: GPL v2 or later
  *
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'PROPERF_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PROPERF_URL', plugin_dir_url( __FILE__ ) );
-define( 'PROPERF_VERSION', '1.1.0' );
+define( 'PROPERF_VERSION', '1.1.1' );
 
 require_once PROPERF_DIR . 'includes/class-data-collector.php';
 require_once PROPERF_DIR . 'includes/class-live-data.php';

--- a/properf-wordpress-adapter.php
+++ b/properf-wordpress-adapter.php
@@ -3,7 +3,7 @@
  * Plugin Name: ProPerf WordPress Adapter
  * Plugin URI: https://coloredcow.com
  * Description: Collects and displays database health metrics (autoloaded options)
- * Version: 1.1.1
+ * Version: 1.2.0
  * Author: ColoredCow
  * License: GPL v2 or later
  *
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'PROPERF_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PROPERF_URL', plugin_dir_url( __FILE__ ) );
-define( 'PROPERF_VERSION', '1.1.1' );
+define( 'PROPERF_VERSION', '1.2.0' );
 
 require_once PROPERF_DIR . 'includes/class-data-collector.php';
 require_once PROPERF_DIR . 'includes/class-live-data.php';


### PR DESCRIPTION
Closes #11

## What changed

Before this PR, the plugin collected autoloaded options and WooCommerce order metrics — enough to know the DB was large, but not enough to know *why* a site was slow. Every slow site looked the same and the engineer had to guess whether the problem was data, code, or plugin bloat. This PR adds three server-level metrics — plugin count, hook count, and DB table sizes — that turn guessing into a systematic triage.

### Server metrics collection

`collect_server_metrics()` in `ProPerf_Data_Collector` now merges two independently-collected, independently-cached pieces:

- **`collect_plugin_stats()`** — active + inactive plugin count (via `array_intersect()` against `get_plugins()` and the `active_plugins` option, including network-activated plugins on multisite) and total registered hook callbacks (all callbacks across every `WP_Hook` entry in `$wp_filter`). Cached under `PLUGIN_METRICS_CACHE_KEY`, busted on plugin activate/deactivate/install/delete.
- **`collect_table_stats()`** — per-table DB sizes from `information_schema.TABLES`, ordered largest first, plus the total DB size and any table-name encoding warning. Table names containing non-UTF-8 characters are sanitized via `iconv` (guarded — hosts without ext-iconv fall back to the raw name instead of fataling) before display. Cached under `SERVER_METRICS_CACHE_KEY`, on its own TTL, not tied to plugin events.

These two are cached separately because they have different invalidation triggers: plugin toggles shouldn't force an expensive `information_schema` re-scan, and DB table growth (general writes) has nothing to do with plugin state.

`get_data()` merges all three collectors. `format_for_bigquery()` includes 4 new scalar columns pushed on every sync — per-table sizes are dashboard-only.

### Dashboard

Two new sections added to **ProPerf → Dashboard**:
- **Server Metrics** — active/inactive plugin count, hook count, total DB size
- **Top 10 Database Tables by Size** — largest tables only, capped at 10 rows to keep it readable

Per-table sizes are not pushed to BigQuery.

### BigQuery schema migration

**Responsible: Ajay**

The load job is configured with `ALLOW_FIELD_ADDITION`, so these 4 new columns should be added automatically on the first push after the plugin is updated. If they aren't, add them manually in BigQuery Console: open the table → **Edit Schema → Edit as text**, add the following entries and save:

```json
{ "name": "active_plugin_count", "type": "INTEGER", "mode": "NULLABLE" },
{ "name": "inactive_plugin_count", "type": "INTEGER", "mode": "NULLABLE" },
{ "name": "hook_count", "type": "INTEGER", "mode": "NULLABLE" },
{ "name": "total_db_size_mb", "type": "FLOAT", "mode": "NULLABLE" }
```

## Code quality / correctness fixes

- **Stale transient post-deploy** — cache is now busted on plugin activation via `register_activation_hook` so the dashboard reflects fresh data immediately after update.
- **`activated_plugin`/`deactivated_plugin`/`deleted_plugin`/plugin-install hooks all wired** — previously only activate/deactivate busted the plugin cache; installing a new (inactive) plugin or deleting one also changes the plugin count but wasn't covered. Added `deleted_plugin` and an `upgrader_process_complete` install-type check alongside the existing activate/deactivate hooks, and moved all of them off `admin_init` so WP-CLI and REST paths are covered too.
- **`collect_and_push()` now busts all caches via `bust_metrics_cache()`** — previously listed transients individually and could drift out of sync with the actual set of caches; now calls the single aggregator.
- **`iconv()` unguarded → uncaught fatal** — `iconv()` was called with no `function_exists()` check, unlike the `get_plugins()` guard two lines above it. On a PHP build without ext-iconv this threw an `Error` (not an `Exception`), which the surrounding `catch ( Exception $e )` in both the dashboard render and the cron push does not catch — the whole page/push fatals instead of degrading. Now guarded the same way `get_plugins()` is.
- **Multisite undercounts active plugins** — `active_plugin_count` only read the per-site `active_plugins` option, missing network-activated plugins (`active_sitewide_plugins`), which were silently counted as inactive. Now included when `is_multisite()`.
- **`db_table_sizes` key collision silently dropped a table** — two distinct corrupted table names that both sanitize to the same string overwrote each other in the array while `total_db_size_mb` still counted both, so the displayed rows no longer summed to the displayed total. Now accumulates instead of overwriting on collision.
- **Fully-invalid table names were excluded from the total, not just the display** — a table name `iconv` couldn't clean at all (`false`/`''`) skipped the row before it was added to `total_db_size_mb`, silently undercounting real DB size. The size is now always added to the total; only the per-table display row is skipped when the name is unusable.
- **Encoding-warning option retired** — `properf_table_name_encoding_warning` was autoloaded (no `false` argument, unlike other options in this file), and required a get/update/delete sync dance on every cache read. It only had one consumer (the dashboard render, which already has fresh `$metrics` in hand), so it's gone entirely — the warning now lives at `$metrics['server']['table_name_warning']`, read directly, with no separate option and no stray top-level key leaking through `get_data()`'s `array_merge()`.
- **Settings field double-cached WooCommerce metrics** — `order_itemmeta_alert_threshold_mb_field()` checked the WOO transient itself, called `collect_woo_order_metrics()` (which checks and sets the same transient internally), then set it a third time with the identical value. Removed the redundant wrapper — the collector already owns its own caching.
- **`$wp_filter` PHP 8 fatal** — the hook callback counter accessed `->callbacks` on every `$wp_filter` entry without checking it's a `WP_Hook` object. Added `instanceof WP_Hook` guard.
- **`number_format(null)` crash on PHP 8.2** — `order_itemmeta_size_mb` can be null when the WooCommerce itemmeta table does not exist. The archival signal banner now requires a non-null size before rendering, and the table row shows `—` instead of crashing.
- **`$_POST` unit read in sanitize callback** — the alert threshold sanitizer reads the unit dropdown from `$_POST`, which is empty in WP-CLI and REST API contexts. Added `!empty($_POST)` guard so non-HTTP callers don't silently store the wrong threshold.
- **Misleading notice on fresh store** — the threshold field showed "No archivable orders found" on a zero-order store. It now shows "No orders yet" when `total_orders` is also zero.
- **`validate_active_plugins()` replaced with `array_intersect()`** — the original writes back to the DB and is unsafe in cron context. Replaced with a read-only `array_intersect()` against `array_keys(get_plugins())`.
- **Cache busting scoped** — split into `bust_woo_metrics_cache()`, `bust_autoload_metrics_cache()`, `bust_plugin_metrics_cache()`, and `bust_server_metrics_cache()` so each setting or event only invalidates the data it actually affects.
- **`collect_autoloaded_options()` uncached** — added 1-hour transient cache with `AUTOLOAD_METRICS_CACHE_KEY`, consistent with the other collectors.
- **Duplicate `properf_bq_last_sync` write** — removed from the BigQuery client; `collect_and_push()` already writes it.
- **Hardcoded cache key string in settings** — replaced raw string with `ProPerf_Data_Collector::WOO_METRICS_CACHE_KEY` constant.
- **`db_table_sizes` not pushed to BigQuery** — dropped from `format_for_bigquery()` and the BigQuery client's load schema.
- **Variable alignment** — fixed inconsistent spacing in `render_dashboard()` variable assignments; moved `$table_name_warning` assignment to the variables block before the template.

## Future work landing cleanly on this structure

- #35 — high hook count, high plugin count, and abnormal DB size growth alert types now have the data they need to fire from BigQuery (`hook_count`, `active_plugin_count`, `total_db_size_mb`)
- #34 — external notification delivery can build on top of these metrics once #35's thresholds are confirmed

## Acceptance criteria
- [x] **ProPerf → Dashboard** shows Server Metrics section with active/inactive plugin count, hook count, total DB size — verified on sankalptaru
- [x] **Top 10 Database Tables by Size** section shows at most 10 rows, ordered largest first — verified
- [x] Push to BigQuery succeeds and all 4 new scalar columns are non-null in the latest row — verified
- [ ] Dashboard renders without errors on a site where WooCommerce is not active
- [ ] Activating/updating the plugin clears the plugin metrics cache immediately; WooCommerce setting changes do not trigger an `information_schema` scan
- [ ] Setting the alert threshold via WP-CLI stores the correct MB value
- [ ] Dashboard encoding warning appears when a table name contains non-UTF-8 characters and clears when the condition is resolved
- [ ] Installing (without activating) or deleting a plugin updates the plugin count without waiting for the 1-hour cache TTL